### PR TITLE
Feature: query delay

### DIFF
--- a/src/io/cli.rs
+++ b/src/io/cli.rs
@@ -53,6 +53,10 @@ pub struct CommandArgs {
     /// Print which resolver was used for each query
     #[arg(long)]
     pub show_resolver: bool,
+
+    /// Delay in milliseconds between DNS requests
+    #[arg(long, required = false)]
+    pub delay: Option<u64>,
 }
 
 pub fn get_parsed_args() -> CommandArgs {
@@ -69,10 +73,13 @@ pub fn print_options(args: &CommandArgs) {
     println!("{}: {}", "records".bright_blue(), args.query_type);
     println!("{}: {}", "resolvers".bright_blue(), args.dns_resolvers);
     println!(
-        "{}: {}\n",
+        "{}: {}",
         "show-resolver".bright_blue(),
         args.show_resolver
     );
+    if let Some(delay_ms) = args.delay {
+        println!("{}: {}ms\n", "delay".bright_blue(), delay_ms);
+    }
 }
 
 pub fn print_ascii_art() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use io::cli::CommandArgs;
 use rand::seq::IteratorRandom;
 use rand::thread_rng;
 use std::net::UdpSocket;
+use std::thread;
 use std::time::Duration;
 
 use crate::dns::types::ResponseType;
@@ -68,11 +69,15 @@ fn main() -> Result<()> {
         }
 
         cli::update_progress_bar(&progress_bar, index, total_subdomains);
+
+        if let Some(delay_ms) = args.delay {
+            thread::sleep(Duration::from_millis(delay_ms));
+        }
     }
 
     progress_bar.finish_and_clear();
 
-    println!("\nDone! Found {found_count} domains");
+    println!("\nDone! Found {found_count} subdomains");
     Ok(())
 }
 


### PR DESCRIPTION
Adds the option to have a delay between requests. Provided by command-line argument as milliseconds:

` --delay <DELAY>                  Delay in milliseconds between DNS requests`

Argument type: `u64`