### PR TITLE
Refactor Protocol Data Structures

### DIFF
--- a/src/dns/protocol.rs
+++ b/src/dns/protocol.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::struct_excessive_bools)]
+#![allow(clippy::too_many_lines)]
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::Result;
 use clap::ValueEnum;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::Serialize;
@@ -51,27 +52,26 @@ pub enum ResultCode {
     REFUSED = 5,
 }
 
-// Structs and their implementations
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct DnsHeader {
-    pub id: u16, // 16 bits
+    pub id: u16,
 
-    pub recursion_desired: bool,    // 1 bit
-    pub truncated_message: bool,    // 1 bit
-    pub authoritative_answer: bool, // 1 bit
-    pub opcode: u8,                 // 4 bits
-    pub response: bool,             // 1 bit
+    pub recursion_desired: bool,
+    pub truncated_message: bool,
+    pub authoritative_answer: bool,
+    pub opcode: u8,
+    pub response: bool,
 
-    pub rescode: ResultCode,       // 4 bits
-    pub checking_disabled: bool,   // 1 bit
-    pub authed_data: bool,         // 1 bit
-    pub z: bool,                   // 1 bit
-    pub recursion_available: bool, // 1 bit
+    pub rescode: ResultCode,
+    pub checking_disabled: bool,
+    pub authed_data: bool,
+    pub z: bool,
+    pub recursion_available: bool,
 
-    pub questions: u16,             // 16 bits
-    pub answers: u16,               // 16 bits
-    pub authoritative_entries: u16, // 16 bits
-    pub resource_entries: u16,      // 16 bits
+    pub questions: u16,
+    pub answers: u16,
+    pub authoritative_entries: u16,
+    pub resource_entries: u16,
 }
 
 impl DnsHeader {
@@ -154,217 +154,193 @@ impl DnsHeader {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct DnsQuestion {
-    pub domain: String,
+    pub name: String,
     pub qtype: QueryType,
+    pub qclass: u16,
 }
 
 impl DnsQuestion {
-    pub const fn new(domain: String, qtype: QueryType) -> Self {
-        Self { domain, qtype }
+    pub const fn new(name: String, qtype: QueryType) -> Self {
+        Self {
+            name,
+            qtype,
+            qclass: 1,
+        }
     }
 
     pub fn read(&mut self, buffer: &mut PacketBuffer) -> Result<()> {
-        buffer.read_qname(&mut self.domain)?;
+        buffer.read_qname(&mut self.name)?;
         self.qtype = QueryType::try_from(buffer.read_u16()?)?;
-        let _qclass = buffer.read_u16()?;
-
+        self.qclass = buffer.read_u16()?;
         Ok(())
     }
 
     pub fn write(&self, buffer: &mut PacketBuffer) -> Result<()> {
-        buffer.write_qname(&self.domain)?;
-
-        let typenum = self.qtype.clone() as u16;
-        buffer.write_u16(typenum)?;
-        buffer.write_u16(1)?;
-
+        buffer.write_qname(&self.name)?;
+        buffer.write_u16(self.qtype.clone() as u16)?;
+        buffer.write_u16(self.qclass)?;
         Ok(())
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize)]
-pub enum DnsRecord {
-    A(DnsRecordA),
-    AAAA(DnsRecordAAAA),
-    MX(DnsRecordMX),
-    TXT(DnsRecordTXT),
-    CNAME(DnsRecordQNAME),
-    SOA(DnsRecordSOA),
-    NS(DnsRecordQNAME),
-    SRV(DnsRecordSRV),
-    DNSKEY(DnsRecordDNSKEY),
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Hash)]
+pub struct ResourceRecord {
+    pub name: String,
+    pub class: u16,
+    pub ttl: u32,
+    pub data: RData,
 }
 
-impl DnsRecord {
-    pub fn read(buffer: &mut PacketBuffer) -> Result<DnsQueryResponse> {
-        let mut domain = String::new();
-        buffer
-            .read_qname(&mut domain)
-            .context("Failed to read domain name")?;
+impl ResourceRecord {
+    pub fn read(buffer: &mut PacketBuffer) -> Result<Self> {
+        let mut name = String::new();
+        buffer.read_qname(&mut name)?;
 
-        let qtype_num = buffer.read_u16().context("Failed to read query type")?;
+        let qtype_num = buffer.read_u16()?;
         let qtype = QueryType::try_from(qtype_num)?;
-        let _class = buffer.read_u16().context("Failed to read class")?;
-        let ttl = buffer.read_u32().context("Failed to read TTL")?;
-        let data_len = buffer.read_u16().context("Failed to read data length")?;
+        let class = buffer.read_u16()?;
+        let ttl = buffer.read_u32()?;
+        let data_len = buffer.read_u16()? as usize;
 
-        match qtype {
-            QueryType::A => Self::parse_a_record(buffer, domain, ttl),
-            QueryType::AAAA => Self::parse_aaaa_record(buffer, domain, ttl),
-            QueryType::MX => Self::parse_mx_record(buffer, ttl),
-            QueryType::TXT => Self::parse_txt_record(buffer, ttl),
-            QueryType::CNAME => Self::parse_cname_record(buffer, ttl),
-            QueryType::NS => Self::parse_ns_record(buffer, ttl),
-            QueryType::SOA => Self::parse_soa_record(buffer),
-            QueryType::SRV => Self::parse_srv_record(buffer),
-            QueryType::DNSKEY => Self::parse_dnskey_record(buffer, data_len),
-            QueryType::ANY => Err(anyhow!("Unsupported query type {qtype}")),
-        }
-    }
-
-    pub fn write(&self, buffer: &mut PacketBuffer) -> Result<usize> {
-        let start_pos = buffer.pos();
-
-        match *self {
-            Self::A(DnsRecordA {
-                ref domain,
-                ref addr,
-                ttl,
-            }) => {
-                buffer.write_qname(domain)?;
-                buffer.write_u16(QueryType::A as u16)?;
-                buffer.write_u16(1)?;
-                buffer.write_u32(ttl)?;
-                buffer.write_u16(4)?;
-
-                let octets = addr.octets();
-                buffer.write_u8(octets[0])?;
-                buffer.write_u8(octets[1])?;
-                buffer.write_u8(octets[2])?;
-                buffer.write_u8(octets[3])?;
+        let data = match qtype {
+            QueryType::A => {
+                let ip_raw = buffer.read_u32()?;
+                let ip = Ipv4Addr::from(ip_raw);
+                RData::A(ip)
             }
-            _ => unimplemented!(),
-        }
+            QueryType::AAAA => {
+                let mut segments = [0u16; 8];
+                for segment in &mut segments {
+                    *segment = buffer.read_u16()?;
+                }
+                let ip = Ipv6Addr::from(segments);
+                RData::AAAA(ip)
+            }
+            QueryType::NS => {
+                let mut ns = String::new();
+                buffer.read_qname(&mut ns)?;
+                RData::NS(ns)
+            }
+            QueryType::CNAME => {
+                let mut cname = String::new();
+                buffer.read_qname(&mut cname)?;
+                RData::CNAME(cname)
+            }
+            QueryType::MX => {
+                let preference = buffer.read_u16()?;
+                let mut exchange = String::new();
+                buffer.read_qname(&mut exchange)?;
+                RData::MX {
+                    preference,
+                    exchange,
+                }
+            }
+            QueryType::TXT => {
+                let txt_len = buffer.read_u8()? as usize;
+                let mut txt_data = String::new();
 
-        Ok(buffer.pos() - start_pos)
-    }
+                for _ in 0..txt_len {
+                    txt_data.push(buffer.read_u8()? as char);
+                }
+                RData::TXT(txt_data)
+            }
+            QueryType::SOA => {
+                let mut mname = String::new();
+                buffer.read_qname(&mut mname)?;
+                let mut rname = String::new();
+                buffer.read_qname(&mut rname)?;
+                let serial = buffer.read_u32()?;
+                let refresh = buffer.read_u32()?;
+                let retry = buffer.read_u32()?;
+                let expire = buffer.read_u32()?;
+                let minimum = buffer.read_u32()?;
+                RData::SOA {
+                    mname,
+                    rname,
+                    serial,
+                    refresh,
+                    retry,
+                    expire,
+                    minimum,
+                }
+            }
+            QueryType::SRV => {
+                let priority = buffer.read_u16()?;
+                let weight = buffer.read_u16()?;
+                let port = buffer.read_u16()?;
+                let mut target = String::new();
+                buffer.read_qname(&mut target)?;
+                RData::SRV {
+                    priority,
+                    weight,
+                    port,
+                    target,
+                }
+            }
+            QueryType::DNSKEY => {
+                let flags = buffer.read_u16()?;
+                let protocol = buffer.read_u8()?;
+                let algorithm = buffer.read_u8()?;
+                let key_len = data_len - 4;
+                let public_key = buffer.read_bytes(key_len)?;
+                RData::DNSKEY {
+                    flags,
+                    protocol,
+                    algorithm,
+                    public_key,
+                }
+            }
+            QueryType::ANY => {
+                buffer.step(data_len)?;
+                RData::Unknown { qtype, data_len }
+            }
+        };
 
-    fn parse_a_record(
-        buffer: &mut PacketBuffer,
-        domain: String,
-        ttl: u32,
-    ) -> Result<DnsQueryResponse> {
-        let raw_addr = buffer.read_u32()?;
-        let addr = Ipv4Addr::new(
-            ((raw_addr >> 24) & 0xFF) as u8,
-            ((raw_addr >> 16) & 0xFF) as u8,
-            ((raw_addr >> 8) & 0xFF) as u8,
-            (raw_addr & 0xFF) as u8,
-        );
-
-        Ok(DnsQueryResponse {
-            query_type: QueryType::A,
-            response_content: Self::A(DnsRecordA { ttl, domain, addr }),
+        Ok(Self {
+            name,
+            class,
+            ttl,
+            data,
         })
     }
 
-    fn parse_aaaa_record(
-        buffer: &mut PacketBuffer,
-        domain: String,
-        ttl: u32,
-    ) -> Result<DnsQueryResponse> {
-        let raw_addr1 = buffer.read_u32()?;
-        let raw_addr2 = buffer.read_u32()?;
-        let raw_addr3 = buffer.read_u32()?;
-        let raw_addr4 = buffer.read_u32()?;
-        let addr = Ipv6Addr::new(
-            ((raw_addr1 >> 16) & 0xFFFF) as u16,
-            (raw_addr1 & 0xFFFF) as u16,
-            ((raw_addr2 >> 16) & 0xFFFF) as u16,
-            (raw_addr2 & 0xFFFF) as u16,
-            ((raw_addr3 >> 16) & 0xFFFF) as u16,
-            (raw_addr3 & 0xFFFF) as u16,
-            ((raw_addr4 >> 16) & 0xFFFF) as u16,
-            (raw_addr4 & 0xFFFF) as u16,
-        );
+    pub fn write(&self, buffer: &mut PacketBuffer) -> Result<()> {
+        buffer.write_qname(&self.name)?;
+        buffer.write_u16(self.data.to_qtype() as u16)?;
+        buffer.write_u16(self.class)?;
+        buffer.write_u32(self.ttl)?;
 
-        Ok(DnsQueryResponse {
-            query_type: QueryType::AAAA,
-            response_content: Self::AAAA(DnsRecordAAAA { ttl, domain, addr }),
-        })
-    }
+        // Placeholder for the length
+        let length_pos = buffer.pos();
+        buffer.write_u16(0)?;
 
-    fn parse_mx_record(buffer: &mut PacketBuffer, ttl: u32) -> Result<DnsQueryResponse> {
-        let priority = buffer.read_u16()?;
-        let mut mx_domain = String::new();
-        buffer.read_qname(&mut mx_domain)?;
-
-        Ok(DnsQueryResponse {
-            query_type: QueryType::MX,
-            response_content: Self::MX(DnsRecordMX {
-                ttl,
-                priority,
-                domain: mx_domain,
-            }),
-        })
-    }
-
-    fn parse_txt_record(buffer: &mut PacketBuffer, ttl: u32) -> Result<DnsQueryResponse> {
-        let mut txt_data = String::new();
-
-        let data_len = buffer.read_u8()?;
-        for _ in 0..data_len {
-            txt_data.push(buffer.read_u8()? as char);
-        }
-
-        Ok(DnsQueryResponse {
-            query_type: QueryType::TXT,
-            response_content: Self::TXT(DnsRecordTXT {
-                ttl,
-                data: txt_data,
-            }),
-        })
-    }
-
-    fn parse_cname_record(buffer: &mut PacketBuffer, ttl: u32) -> Result<DnsQueryResponse> {
-        let mut cname = String::new();
-        buffer.read_qname(&mut cname)?;
-
-        Ok(DnsQueryResponse {
-            query_type: QueryType::CNAME,
-            response_content: Self::CNAME(DnsRecordTXT { ttl, data: cname }),
-        })
-    }
-
-    fn parse_ns_record(buffer: &mut PacketBuffer, ttl: u32) -> Result<DnsQueryResponse> {
-        let mut ns_domain = String::new();
-        buffer.read_qname(&mut ns_domain)?;
-
-        Ok(DnsQueryResponse {
-            query_type: QueryType::NS,
-            response_content: Self::NS(DnsRecordTXT {
-                ttl,
-                data: ns_domain,
-            }),
-        })
-    }
-
-    fn parse_soa_record(buffer: &mut PacketBuffer) -> Result<DnsQueryResponse> {
-        let mut mname = String::new();
-        buffer.read_qname(&mut mname)?;
-
-        let mut rname = String::new();
-        buffer.read_qname(&mut rname)?;
-
-        let serial = buffer.read_u32()?;
-        let refresh = buffer.read_u32()?;
-        let retry = buffer.read_u32()?;
-        let expire = buffer.read_u32()?;
-        let minimum = buffer.read_u32()?;
-
-        Ok(DnsQueryResponse {
-            query_type: QueryType::SOA,
-            response_content: Self::SOA(DnsRecordSOA {
+        let start_pos = buffer.pos();
+        match &self.data {
+            RData::A(ip) => {
+                buffer.write_u32(u32::from(*ip))?;
+            }
+            RData::AAAA(ip) => {
+                for segment in &ip.segments() {
+                    buffer.write_u16(*segment)?;
+                }
+            }
+            RData::NS(ns) | RData::CNAME(ns) => {
+                buffer.write_qname(ns)?;
+            }
+            RData::MX {
+                preference,
+                exchange,
+            } => {
+                buffer.write_u16(*preference)?;
+                buffer.write_qname(exchange)?;
+            }
+            RData::TXT(txt) => {
+                buffer.write_u8(u8::try_from(txt.len())?)?;
+                for byte in txt.as_bytes() {
+                    buffer.write_u8(*byte)?;
+                }
+            }
+            RData::SOA {
                 mname,
                 rname,
                 serial,
@@ -372,117 +348,117 @@ impl DnsRecord {
                 retry,
                 expire,
                 minimum,
-            }),
-        })
-    }
-
-    fn parse_srv_record(buffer: &mut PacketBuffer) -> Result<DnsQueryResponse> {
-        let priority = buffer.read_u16()?;
-        let weight = buffer.read_u16()?;
-        let port = buffer.read_u16()?;
-        let mut target = String::new();
-        buffer.read_qname(&mut target)?;
-
-        Ok(DnsQueryResponse {
-            query_type: QueryType::SRV,
-            response_content: Self::SRV(DnsRecordSRV {
+            } => {
+                buffer.write_qname(mname)?;
+                buffer.write_qname(rname)?;
+                buffer.write_u32(*serial)?;
+                buffer.write_u32(*refresh)?;
+                buffer.write_u32(*retry)?;
+                buffer.write_u32(*expire)?;
+                buffer.write_u32(*minimum)?;
+            }
+            RData::SRV {
                 priority,
                 weight,
                 port,
                 target,
-            }),
-        })
-    }
-
-    fn parse_dnskey_record(buffer: &mut PacketBuffer, data_len: u16) -> Result<DnsQueryResponse> {
-        let flags = buffer.read_u16()?;
-        let protocol = buffer.read_u8()?;
-        let algorithm = buffer.read_u8()?;
-
-        // Read the remaining bytes as the public key
-        let public_key = buffer.read_bytes((data_len - 4).into())?;
-
-        Ok(DnsQueryResponse {
-            query_type: QueryType::DNSKEY,
-            response_content: Self::DNSKEY(DnsRecordDNSKEY {
+            } => {
+                buffer.write_u16(*priority)?;
+                buffer.write_u16(*weight)?;
+                buffer.write_u16(*port)?;
+                buffer.write_qname(target)?;
+            }
+            RData::DNSKEY {
                 flags,
                 protocol,
                 algorithm,
                 public_key,
-            }),
-        })
+            } => {
+                buffer.write_u16(*flags)?;
+                buffer.write_u8(*protocol)?;
+                buffer.write_u8(*algorithm)?;
+                for byte in public_key {
+                    buffer.write_u8(*byte)?;
+                }
+            }
+            RData::Unknown { data_len, .. } => {
+                for _ in 0..*data_len {
+                    buffer.write_u8(0)?;
+                }
+            }
+        }
+
+        let end_pos = buffer.pos();
+        let size = u16::try_from(end_pos - start_pos)?;
+
+        buffer.set_u16(length_pos, size)?;
+
+        Ok(())
     }
 }
 
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize)]
-pub struct DnsRecordA {
-    pub ttl: u32,
-    pub domain: String,
-    pub addr: Ipv4Addr,
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Hash)]
+pub enum RData {
+    A(Ipv4Addr),
+    AAAA(Ipv6Addr),
+    NS(String),
+    CNAME(String),
+    MX {
+        preference: u16,
+        exchange: String,
+    },
+    TXT(String),
+    SOA {
+        mname: String,
+        rname: String,
+        serial: u32,
+        refresh: u32,
+        retry: u32,
+        expire: u32,
+        minimum: u32,
+    },
+    SRV {
+        priority: u16,
+        weight: u16,
+        port: u16,
+        target: String,
+    },
+    DNSKEY {
+        flags: u16,
+        protocol: u8,
+        algorithm: u8,
+        public_key: Vec<u8>,
+    },
+    Unknown {
+        qtype: QueryType,
+        data_len: usize,
+    },
 }
 
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize)]
-pub struct DnsRecordAAAA {
-    pub ttl: u32,
-    pub domain: String,
-    pub addr: Ipv6Addr,
-}
-
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize)]
-pub struct DnsRecordMX {
-    pub ttl: u32,
-    pub priority: u16,
-    pub domain: String,
-}
-
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize)]
-pub struct DnsRecordSOA {
-    pub mname: String,
-    pub rname: String,
-    pub serial: u32,
-    pub refresh: u32,
-    pub retry: u32,
-    pub expire: u32,
-    pub minimum: u32,
-}
-
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize)]
-pub struct DnsRecordTXT {
-    pub ttl: u32,
-    pub data: String,
-}
-
-pub type DnsRecordQNAME = DnsRecordTXT;
-
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize)]
-pub struct DnsRecordSRV {
-    pub priority: u16,
-    pub weight: u16,
-    pub port: u16,
-    pub target: String,
-}
-
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize)]
-pub struct DnsRecordDNSKEY {
-    pub flags: u16,
-    pub protocol: u8,
-    pub algorithm: u8,
-    pub public_key: Vec<u8>,
-}
-
-#[derive(Clone, Eq, PartialEq, Hash, Debug, Serialize)]
-pub struct DnsQueryResponse {
-    pub query_type: QueryType,
-    pub response_content: DnsRecord,
+impl RData {
+    pub fn to_qtype(&self) -> QueryType {
+        match self {
+            Self::A(_) => QueryType::A,
+            Self::AAAA(_) => QueryType::AAAA,
+            Self::NS(_) => QueryType::NS,
+            Self::CNAME(_) => QueryType::CNAME,
+            Self::MX { .. } => QueryType::MX,
+            Self::TXT(_) => QueryType::TXT,
+            Self::SOA { .. } => QueryType::SOA,
+            Self::SRV { .. } => QueryType::SRV,
+            Self::DNSKEY { .. } => QueryType::DNSKEY,
+            Self::Unknown { qtype, .. } => qtype.clone(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct DnsPacket {
     pub header: DnsHeader,
     pub questions: Vec<DnsQuestion>,
-    pub answers: Vec<DnsQueryResponse>,
-    pub authorities: Vec<DnsQueryResponse>,
-    pub resources: Vec<DnsQueryResponse>,
+    pub answers: Vec<ResourceRecord>,
+    pub authorities: Vec<ResourceRecord>,
+    pub resources: Vec<ResourceRecord>,
 }
 
 impl DnsPacket {
@@ -512,18 +488,18 @@ impl DnsPacket {
         }
 
         for _ in 0..result.header.answers {
-            let rec = DnsRecord::read(buffer)
+            let rec = ResourceRecord::read(buffer)
                 .map_err(|_| DnsError::ProtocolData("Failed to read DNS answer".to_owned()))?;
             result.answers.push(rec);
         }
         for _ in 0..result.header.authoritative_entries {
-            let rec = DnsRecord::read(buffer).map_err(|_| {
-                DnsError::ProtocolData("Failed to read DNS authoritative entry".to_owned())
+            let rec = ResourceRecord::read(buffer).map_err(|_| {
+                DnsError::ProtocolData("Failed to read DNS authoritive entry".to_owned())
             })?;
             result.authorities.push(rec);
         }
         for _ in 0..result.header.resource_entries {
-            let rec = DnsRecord::read(buffer).map_err(|_| {
+            let rec = ResourceRecord::read(buffer).map_err(|_| {
                 DnsError::ProtocolData("Failed to read DNS resource entry".to_owned())
             })?;
             result.resources.push(rec);
@@ -532,11 +508,12 @@ impl DnsPacket {
         Ok(result)
     }
 
+    #[allow(clippy::cast_possible_truncation)]
     pub fn write(&mut self, buffer: &mut PacketBuffer) -> Result<(), DnsError> {
-        self.header.questions = u16::try_from(self.questions.len()).unwrap_or(0);
-        self.header.answers = u16::try_from(self.answers.len()).unwrap_or(0);
-        self.header.authoritative_entries = u16::try_from(self.authorities.len()).unwrap_or(0);
-        self.header.resource_entries = u16::try_from(self.resources.len()).unwrap_or(0);
+        self.header.questions = self.questions.len() as u16;
+        self.header.answers = self.answers.len() as u16;
+        self.header.authoritative_entries = self.authorities.len() as u16;
+        self.header.resource_entries = self.resources.len() as u16;
 
         self.header
             .write(buffer)
@@ -548,19 +525,16 @@ impl DnsPacket {
                 .map_err(|_| DnsError::ProtocolData("Failed to write DNS question".to_owned()))?;
         }
         for rec in &self.answers {
-            rec.response_content
-                .write(buffer)
+            rec.write(buffer)
                 .map_err(|_| DnsError::ProtocolData("Failed to write DNS answer".to_owned()))?;
         }
         for rec in &self.authorities {
-            rec.response_content.write(buffer).map_err(|_| {
-                DnsError::ProtocolData("Failed to write DNS authoritative entry".to_owned())
-            })?;
+            rec.write(buffer)
+                .map_err(|_| DnsError::ProtocolData("Failed to write DNS authority".to_owned()))?;
         }
         for rec in &self.resources {
-            rec.response_content.write(buffer).map_err(|_| {
-                DnsError::ProtocolData("Failed to write DNS resource entry".to_owned())
-            })?;
+            rec.write(buffer)
+                .map_err(|_| DnsError::ProtocolData("Failed to write DNS resources".to_owned()))?;
         }
 
         Ok(())
@@ -570,6 +544,7 @@ impl DnsPacket {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::io::packet_buffer::PacketBuffer;
 
     #[test]
     fn test_query_type_from_number() {
@@ -652,19 +627,20 @@ mod tests {
     }
 
     #[test]
-    fn test_dns_record_read_write() {
+    fn test_resource_record_read_write() {
         let mut buffer = PacketBuffer::new();
-        let record = DnsRecord::A(DnsRecordA {
-            domain: "example.com".to_string(),
-            addr: Ipv4Addr::new(127, 0, 0, 1),
+        let record = ResourceRecord {
+            name: "example.com".to_string(),
+            class: 1,
             ttl: 3600,
-        });
+            data: RData::A(Ipv4Addr::new(127, 0, 0, 1)),
+        };
 
         record.write(&mut buffer).unwrap();
         buffer.set_pos(0).unwrap();
-        let read_record = DnsRecord::read(&mut buffer).unwrap();
+        let read_record = ResourceRecord::read(&mut buffer).unwrap();
 
-        assert_eq!(record, read_record.response_content);
+        assert_eq!(record, read_record);
     }
 
     #[test]
@@ -675,13 +651,11 @@ mod tests {
         packet
             .questions
             .push(DnsQuestion::new("example.com".to_string(), QueryType::A));
-        packet.answers.push(DnsQueryResponse {
-            query_type: QueryType::A,
-            response_content: DnsRecord::A(DnsRecordA {
-                domain: "example.com".to_string(),
-                addr: Ipv4Addr::new(127, 0, 0, 1),
-                ttl: 3600,
-            }),
+        packet.answers.push(ResourceRecord {
+            name: "example.com".to_string(),
+            class: 1,
+            ttl: 3600,
+            data: RData::A(Ipv4Addr::new(127, 0, 0, 1)),
         });
 
         packet.write(&mut buffer).unwrap();
@@ -689,512 +663,5 @@ mod tests {
         let read_packet = DnsPacket::from_buffer(&mut buffer).unwrap();
 
         assert_eq!(packet, read_packet);
-    }
-
-    // Test reading a DNS packet from a byte array with record type A
-    #[test]
-    fn test_dns_packet_read_response_a() {
-        // Mock DNS response byte array
-        let response_bytes: [u8; 45] = [
-            0x12, 0x34, // ID
-            0x81, 0x80, // Flags
-            0x00, 0x01, // Questions
-            0x00, 0x01, // Answer RRs
-            0x00, 0x00, // Authority RRs
-            0x00, 0x00, // Additional RRs
-            // Question section
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-            0x00, 0x01, // Type A
-            0x00, 0x01, // Class IN
-            // Answer section
-            0xc0, 0x0c, // Name (pointer to offset 12)
-            0x00, 0x01, // Type A
-            0x00, 0x01, // Class IN
-            0x00, 0x00, 0x0e, 0x10, // TTL (3600 seconds)
-            0x00, 0x04, // Data length
-            0x7f, 0x00, 0x00, 0x01, // Address 127.0.0.1
-        ];
-
-        let mut buffer = PacketBuffer::new();
-        buffer.set_data(&response_bytes).unwrap();
-        let packet = DnsPacket::from_buffer(&mut buffer).unwrap();
-
-        // Assertions
-        assert_eq!(packet.header.id, 0x1234);
-        assert!(packet.header.recursion_desired);
-        assert_eq!(packet.header.questions, 1);
-        assert_eq!(packet.header.answers, 1);
-        assert_eq!(packet.header.authoritative_entries, 0);
-        assert_eq!(packet.header.resource_entries, 0);
-
-        assert_eq!(packet.questions.len(), 1);
-        assert_eq!(packet.questions[0].domain, "example.com");
-        assert_eq!(packet.questions[0].qtype, QueryType::A);
-
-        assert_eq!(packet.answers.len(), 1);
-        if let DnsRecord::A(ref a_record) = packet.answers[0].response_content {
-            assert_eq!(a_record.domain, "example.com");
-            assert_eq!(a_record.addr, Ipv4Addr::new(127, 0, 0, 1));
-            assert_eq!(a_record.ttl, 3600);
-        } else {
-            panic!("Expected A record");
-        }
-    }
-
-    // Test reading a DNS packet from a byte array with record type AAAA
-    #[test]
-    fn test_dns_packet_read_response_aaaa() {
-        // Mock DNS response byte array with AAAA record
-        let response_bytes: [u8; 55] = [
-            0x12, 0x34, // ID
-            0x81, 0x80, // Flags
-            0x00, 0x01, // Questions
-            0x00, 0x01, // Answer RRs
-            0x00, 0x00, // Authority RRs
-            0x00, 0x00, // Additional RRs
-            // Question section
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-            0x00, 0x1c, // Type AAAA
-            0x00, 0x01, // Class IN
-            // Answer section
-            0xc0, 0x0c, // Name (pointer to offset 12)
-            0x00, 0x1c, // Type AAAA
-            0x00, 0x01, // Class IN
-            0x00, 0x00, 0x0e, 0x10, // TTL (3600 seconds)
-            0x00, 0x10, // Data length
-            0x20, 0x01, 0x0d, 0xb8, 0x85, 0xa3, 0x00,
-            0x00, // Address 2001:db8:85a3::8a2e:370:7334
-            0x8a, 0x2e, 0x03, 0x70, 0x73, 0x34,
-        ];
-
-        let mut buffer = PacketBuffer::new();
-        buffer.set_data(&response_bytes).unwrap();
-        let packet = DnsPacket::from_buffer(&mut buffer).unwrap();
-
-        // Assertions
-        assert_eq!(packet.header.id, 0x1234);
-        assert!(packet.header.recursion_desired);
-        assert_eq!(packet.header.questions, 1);
-        assert_eq!(packet.header.answers, 1);
-        assert_eq!(packet.header.authoritative_entries, 0);
-        assert_eq!(packet.header.resource_entries, 0);
-
-        assert_eq!(packet.questions.len(), 1);
-        assert_eq!(packet.questions[0].domain, "example.com");
-        assert_eq!(packet.questions[0].qtype, QueryType::AAAA);
-
-        assert_eq!(packet.answers.len(), 1);
-        if let DnsRecord::AAAA(ref aaaa_record) = packet.answers[0].response_content {
-            assert_eq!(aaaa_record.domain, "example.com");
-            assert_eq!(
-                aaaa_record.addr,
-                Ipv6Addr::new(0x2001, 0x0db8, 0x85a3, 0x0000, 0x8a2e, 0x0370, 0x7334, 0x0000)
-            );
-            assert_eq!(aaaa_record.ttl, 3600);
-        } else {
-            panic!("Expected AAAA record");
-        }
-    }
-
-    // Test reading a DNS packet from a byte array with record type MX
-    #[test]
-    fn test_dns_packet_read_response_mx() {
-        // Mock DNS response byte array with MX record
-        let response_bytes: [u8; 50] = [
-            0x12, 0x34, // ID
-            0x81, 0x80, // Flags
-            0x00, 0x01, // Questions
-            0x00, 0x01, // Answer RRs
-            0x00, 0x00, // Authority RRs
-            0x00, 0x00, // Additional RRs
-            // Question section
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-            0x00, 0x0f, // Type MX
-            0x00, 0x01, // Class IN
-            // Answer section
-            0xc0, 0x0c, // Name (pointer to offset 12)
-            0x00, 0x0f, // Type MX
-            0x00, 0x01, // Class IN
-            0x00, 0x00, 0x0e, 0x10, // TTL (3600 seconds)
-            0x00, 0x11, // Data length
-            0x00, 0x0a, // Preference
-            0x04, 0x6d, 0x61, 0x69, 0x6c, // "mail"
-            0xc0, 0x0c, // Pointer to "example.com"
-        ];
-
-        let mut buffer = PacketBuffer::new();
-        buffer.set_data(&response_bytes).unwrap();
-        let packet = DnsPacket::from_buffer(&mut buffer).unwrap();
-
-        // Assertions
-        assert_eq!(packet.header.id, 0x1234);
-        assert!(packet.header.recursion_desired);
-        assert_eq!(packet.header.questions, 1);
-        assert_eq!(packet.header.answers, 1);
-        assert_eq!(packet.header.authoritative_entries, 0);
-        assert_eq!(packet.header.resource_entries, 0);
-
-        assert_eq!(packet.questions.len(), 1);
-        assert_eq!(packet.questions[0].domain, "example.com");
-        assert_eq!(packet.questions[0].qtype, QueryType::MX);
-
-        assert_eq!(packet.answers.len(), 1);
-        if let DnsRecord::MX(ref mx_record) = packet.answers[0].response_content {
-            assert_eq!(mx_record.domain, "mail.example.com");
-            assert_eq!(mx_record.priority, 10);
-            assert_eq!(mx_record.ttl, 3600);
-        } else {
-            panic!("Expected MX record");
-        }
-    }
-
-    // Test reading a DNS packet from a byte array with record type TXT
-    #[test]
-    fn test_dns_packet_read_response_txt() {
-        // Mock DNS response byte array with TXT record
-        let response_bytes: [u8; 78] = [
-            0x12, 0x34, // ID
-            0x81, 0x80, // Flags
-            0x00, 0x01, // Questions
-            0x00, 0x01, // Answer RRs
-            0x00, 0x00, // Authority RRs
-            0x00, 0x00, // Additional RRs
-            // Question section
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-            0x00, 0x10, // Type TXT
-            0x00, 0x01, // Class IN
-            // Answer section
-            0xc0, 0x0c, // Name (pointer to offset 12)
-            0x00, 0x10, // Type TXT
-            0x00, 0x01, // Class IN
-            0x00, 0x00, 0x0e, 0x10, // TTL (3600 seconds)
-            0x00, 0x1c, // Data length (28 bytes)
-            0x24, // TXT data length (27 bytes)
-            0x76, 0x3d, 0x73, 0x70, 0x66, 0x31, 0x20, 0x69, // "v=spf1 i"
-            0x6e, 0x63, 0x6c, 0x75, 0x64, 0x65, 0x3a, 0x5f, // "nclude:_"
-            0x73, 0x70, 0x66, 0x2e, 0x65, 0x78, 0x61, 0x6d, // "spf.exam"
-            0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d, 0x20, // "ple.com "
-            0x7e, 0x61, 0x6c, 0x6c, // "~all"
-        ];
-
-        let mut buffer = PacketBuffer::new();
-        buffer.set_data(&response_bytes).unwrap();
-        let packet = DnsPacket::from_buffer(&mut buffer).unwrap();
-
-        // Assertions
-        assert_eq!(packet.header.id, 0x1234);
-        assert!(packet.header.recursion_desired);
-        assert_eq!(packet.header.questions, 1);
-        assert_eq!(packet.header.answers, 1);
-        assert_eq!(packet.header.authoritative_entries, 0);
-        assert_eq!(packet.header.resource_entries, 0);
-
-        assert_eq!(packet.questions.len(), 1);
-        assert_eq!(packet.questions[0].domain, "example.com");
-        assert_eq!(packet.questions[0].qtype, QueryType::TXT);
-
-        assert_eq!(packet.answers.len(), 1);
-        if let DnsRecord::TXT(ref txt_record) = packet.answers[0].response_content {
-            assert_eq!(txt_record.data, "v=spf1 include:_spf.example.com ~all");
-            assert_eq!(txt_record.ttl, 3600);
-        } else {
-            panic!("Expected TXT record");
-        }
-    }
-
-    // Test reading a DNS packet from a byte array with record type CNAME
-    #[test]
-    fn test_dns_packet_read_response_cname() {
-        // Mock DNS response byte array with CNAME record
-        let response_bytes: [u8; 58] = [
-            0x12, 0x34, // ID
-            0x81, 0x80, // Flags
-            0x00, 0x01, // Questions
-            0x00, 0x01, // Answer RRs
-            0x00, 0x00, // Authority RRs
-            0x00, 0x00, // Additional RRs
-            // Question section
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-            0x00, 0x05, // Type CNAME
-            0x00, 0x01, // Class IN
-            // Answer section
-            0xc0, 0x0c, // Name (pointer to offset 12)
-            0x00, 0x05, // Type CNAME
-            0x00, 0x01, // Class IN
-            0x00, 0x00, 0x0e, 0x10, // TTL (3600 seconds)
-            0x00, 0x0f, // Data length
-            0x03, 0x77, 0x77, 0x77, // "www"
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-        ];
-
-        let mut buffer = PacketBuffer::new();
-        buffer.set_data(&response_bytes).unwrap();
-        let packet = DnsPacket::from_buffer(&mut buffer).unwrap();
-
-        // Assertions
-        assert_eq!(packet.header.id, 0x1234);
-        assert!(packet.header.recursion_desired);
-        assert_eq!(packet.header.questions, 1);
-        assert_eq!(packet.header.answers, 1);
-        assert_eq!(packet.header.authoritative_entries, 0);
-        assert_eq!(packet.header.resource_entries, 0);
-
-        assert_eq!(packet.questions.len(), 1);
-        assert_eq!(packet.questions[0].domain, "example.com");
-        assert_eq!(packet.questions[0].qtype, QueryType::CNAME);
-
-        assert_eq!(packet.answers.len(), 1);
-        if let DnsRecord::CNAME(ref cname_record) = packet.answers[0].response_content {
-            assert_eq!(cname_record.data, "www.example.com");
-            assert_eq!(cname_record.ttl, 3600);
-        } else {
-            panic!("Expected CNAME record");
-        }
-    }
-
-    // Test reading a DNS packet from a byte array with record type SOA
-    #[test]
-    fn test_dns_packet_read_response_soa() {
-        // Mock DNS response byte array with SOA record
-        let response_bytes: [u8; 95] = [
-            0x12, 0x34, // ID
-            0x81, 0x80, // Flags
-            0x00, 0x01, // Questions
-            0x00, 0x01, // Answer RRs
-            0x00, 0x00, // Authority RRs
-            0x00, 0x00, // Additional RRs
-            // Question section
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-            0x00, 0x06, // Type SOA
-            0x00, 0x01, // Class IN
-            // Answer section
-            0xc0, 0x0c, // Name (pointer to offset 12)
-            0x00, 0x06, // Type SOA
-            0x00, 0x01, // Class IN
-            0x00, 0x00, 0x0e, 0x10, // TTL (3600 seconds)
-            0x00, 0x22, // Data length
-            0x03, 0x6e, 0x73, 0x31, // "ns1"
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-            0x03, 0x61, 0x64, 0x6d, // "adm"
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-            0x00, 0x00, 0x00, 0x01, // Serial
-            0x00, 0x00, 0x0e, 0x10, // Refresh
-            0x00, 0x00, 0x0e, 0x10, // Retry
-            0x00, 0x00, 0x0e, 0x10, // Expire
-            0x00, 0x00, 0x0e, 0x10, // Minimum
-        ];
-
-        let mut buffer = PacketBuffer::new();
-        buffer.set_data(&response_bytes).unwrap();
-        let packet = DnsPacket::from_buffer(&mut buffer).unwrap();
-
-        // Assertions
-        assert_eq!(packet.header.id, 0x1234);
-        assert!(packet.header.recursion_desired);
-        assert_eq!(packet.header.questions, 1);
-        assert_eq!(packet.header.answers, 1);
-        assert_eq!(packet.header.authoritative_entries, 0);
-        assert_eq!(packet.header.resource_entries, 0);
-
-        assert_eq!(packet.questions.len(), 1);
-        assert_eq!(packet.questions[0].domain, "example.com");
-        assert_eq!(packet.questions[0].qtype, QueryType::SOA);
-
-        assert_eq!(packet.answers.len(), 1);
-        if let DnsRecord::SOA(ref soa_record) = packet.answers[0].response_content {
-            assert_eq!(soa_record.mname, "ns1.example.com");
-            assert_eq!(soa_record.rname, "adm.example.com");
-            assert_eq!(soa_record.serial, 1);
-            assert_eq!(soa_record.refresh, 3600);
-            assert_eq!(soa_record.retry, 3600);
-            assert_eq!(soa_record.expire, 3600);
-            assert_eq!(soa_record.minimum, 3600);
-        } else {
-            panic!("Expected SOA record");
-        }
-    }
-
-    // Test reading a DNS packet from a byte array with record type NS
-    #[test]
-    fn test_dns_packet_read_response_ns() {
-        // Mock DNS response byte array with NS record
-        let response_bytes: [u8; 58] = [
-            0x12, 0x34, // ID
-            0x81, 0x80, // Flags
-            0x00, 0x01, // Questions
-            0x00, 0x01, // Answer RRs
-            0x00, 0x00, // Authority RRs
-            0x00, 0x00, // Additional RRs
-            // Question section
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-            0x00, 0x02, // Type NS
-            0x00, 0x01, // Class IN
-            // Answer section
-            0xc0, 0x0c, // Name (pointer to offset 12)
-            0x00, 0x02, // Type NS
-            0x00, 0x01, // Class IN
-            0x00, 0x00, 0x0e, 0x10, // TTL (3600 seconds)
-            0x00, 0x0f, // Data length
-            0x03, 0x6e, 0x73, 0x31, // "ns1"
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-        ];
-
-        let mut buffer = PacketBuffer::new();
-        buffer.set_data(&response_bytes).unwrap();
-        let packet = DnsPacket::from_buffer(&mut buffer).unwrap();
-
-        // Assertions
-        assert_eq!(packet.header.id, 0x1234);
-        assert!(packet.header.recursion_desired);
-        assert_eq!(packet.header.questions, 1);
-        assert_eq!(packet.header.answers, 1);
-        assert_eq!(packet.header.authoritative_entries, 0);
-        assert_eq!(packet.header.resource_entries, 0);
-
-        assert_eq!(packet.questions.len(), 1);
-        assert_eq!(packet.questions[0].domain, "example.com");
-        assert_eq!(packet.questions[0].qtype, QueryType::NS);
-
-        assert_eq!(packet.answers.len(), 1);
-        if let DnsRecord::NS(ref ns_record) = packet.answers[0].response_content {
-            assert_eq!(ns_record.data, "ns1.example.com");
-            assert_eq!(ns_record.ttl, 3600);
-        } else {
-            panic!("Expected NS record");
-        }
-    }
-
-    // Test reading a DNS packet from a byte array with record type SRV
-    #[test]
-    fn test_dns_packet_read_response_srv() {
-        // Mock DNS response byte array with SRV record
-        let response_bytes: [u8; 64] = [
-            0x12, 0x34, // ID
-            0x81, 0x80, // Flags
-            0x00, 0x01, // Questions
-            0x00, 0x01, // Answer RRs
-            0x00, 0x00, // Authority RRs
-            0x00, 0x00, // Additional RRs
-            // Question section
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-            0x00, 0x21, // Type SRV
-            0x00, 0x01, // Class IN
-            // Answer section
-            0xc0, 0x0c, // Name (pointer to offset 12)
-            0x00, 0x21, // Type SRV
-            0x00, 0x01, // Class IN
-            0x00, 0x00, 0x0e, 0x10, // TTL (3600 seconds)
-            0x00, 0x15, // Data length
-            0x00, 0x05, // Priority
-            0x00, 0x0a, // Weight
-            0x1f, 0x90, // Port (8080)
-            0x03, 0x77, 0x77, 0x77, // "www"
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-        ];
-
-        let mut buffer = PacketBuffer::new();
-        buffer.set_data(&response_bytes).unwrap();
-        let packet = DnsPacket::from_buffer(&mut buffer).unwrap();
-
-        // Assertions
-        assert_eq!(packet.header.id, 0x1234);
-        assert!(packet.header.recursion_desired);
-        assert_eq!(packet.header.questions, 1);
-        assert_eq!(packet.header.answers, 1);
-        assert_eq!(packet.header.authoritative_entries, 0);
-        assert_eq!(packet.header.resource_entries, 0);
-
-        assert_eq!(packet.questions.len(), 1);
-        assert_eq!(packet.questions[0].domain, "example.com");
-        assert_eq!(packet.questions[0].qtype, QueryType::SRV);
-
-        assert_eq!(packet.answers.len(), 1);
-        if let DnsRecord::SRV(ref srv_record) = packet.answers[0].response_content {
-            assert_eq!(srv_record.priority, 5);
-            assert_eq!(srv_record.weight, 10);
-            assert_eq!(srv_record.port, 8080);
-            assert_eq!(srv_record.target, "www.example.com");
-        } else {
-            panic!("Expected SRV record");
-        }
-    }
-
-    // Test reading a DNS packet from a byte array with record type DNSKEY
-    #[test]
-    fn test_dns_packet_read_response_dnskey() {
-        // Mock DNS response byte array with DNSKEY record
-        let response_bytes: [u8; 77] = [
-            0x12, 0x34, // ID
-            0x81, 0x80, // Flags
-            0x00, 0x01, // Questions
-            0x00, 0x01, // Answer RRs
-            0x00, 0x00, // Authority RRs
-            0x00, 0x00, // Additional RRs
-            // Question section
-            0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, // "example"
-            0x03, 0x63, 0x6f, 0x6d, 0x00, // "com"
-            0x00, 0x30, // Type DNSKEY
-            0x00, 0x01, // Class IN
-            // Answer section
-            0xc0, 0x0c, // Name (pointer to offset 12)
-            0x00, 0x30, // Type DNSKEY
-            0x00, 0x01, // Class IN
-            0x00, 0x00, 0x0e, 0x10, // TTL (3600 seconds)
-            0x00, 0x24, // Data length (36 bytes)
-            // DNSKEY data
-            0x01, 0x01, // Flags
-            0x03, // Protocol
-            0x08, // Algorithm (Ed25519)
-            // Key (32 bytes)
-            0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
-            0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
-            0xAA, 0xAA, 0xAA, 0xFF,
-        ];
-
-        let mut buffer = PacketBuffer::new();
-        buffer.set_data(&response_bytes).unwrap();
-        let packet = DnsPacket::from_buffer(&mut buffer).unwrap();
-
-        // Assertions
-        assert_eq!(packet.header.id, 0x1234);
-        assert!(packet.header.recursion_desired);
-        assert_eq!(packet.header.questions, 1);
-        assert_eq!(packet.header.answers, 1);
-        assert_eq!(packet.header.authoritative_entries, 0);
-        assert_eq!(packet.header.resource_entries, 0);
-
-        assert_eq!(packet.questions.len(), 1);
-        assert_eq!(packet.questions[0].domain, "example.com");
-        assert_eq!(packet.questions[0].qtype, QueryType::DNSKEY);
-
-        assert_eq!(packet.answers.len(), 1);
-        if let DnsRecord::DNSKEY(ref dnskey_record) = packet.answers[0].response_content {
-            assert_eq!(dnskey_record.flags, 0x0101);
-            assert_eq!(dnskey_record.protocol, 3);
-            assert_eq!(dnskey_record.algorithm, 8);
-            assert_eq!(
-                dnskey_record.public_key,
-                [
-                    0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
-                    0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
-                    0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xFF,
-                ]
-            );
-        } else {
-            panic!("Expected DNSKEY record");
-        }
     }
 }

--- a/src/dns/resolver.rs
+++ b/src/dns/resolver.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 
 use crate::dns::error::DnsError;
-use crate::dns::protocol::{DnsQueryResponse, QueryType};
+use crate::dns::protocol::QueryType;
 use crate::io::packet_buffer::PacketBuffer;
 use crate::network::types::TransportProtocol;
 use lazy_static::lazy_static;
@@ -44,7 +44,7 @@ pub fn resolve_domain(
     domain: &str,
     query_type: &QueryType,
     transport_protocol: &TransportProtocol,
-) -> Result<Vec<DnsQueryResponse>, DnsError> {
+) -> Result<DnsPacket, DnsError> {
     let udp_socket =
         initialize_udp_socket().map_err(|error| DnsError::Network(error.to_string()))?;
 
@@ -61,7 +61,7 @@ pub fn resolve_domain(
             if query_result.answers.is_empty() {
                 Err(DnsError::NoRecordsFound)
             } else {
-                Ok(query_result.answers)
+                Ok(query_result)
             }
         }
         ResultCode::NXDOMAIN => Err(DnsError::NonExistentDomain),
@@ -199,7 +199,7 @@ mod tests {
 
         assert_eq!(dns_packet.header.questions, 1);
         assert_eq!(dns_packet.questions.len(), 1);
-        assert_eq!(dns_packet.questions[0].domain, domain);
+        assert_eq!(dns_packet.questions[0].name, domain);
         assert_eq!(dns_packet.questions[0].qtype, query_type);
     }
 

--- a/src/io/json.rs
+++ b/src/io/json.rs
@@ -1,11 +1,11 @@
-use crate::dns::protocol::DnsQueryResponse;
+use crate::dns::protocol::ResourceRecord;
 use anyhow::Result;
 use serde::Serialize;
 
 #[derive(Serialize)]
 pub struct EnumerationOutput {
     pub target_domain: String,
-    pub results: Vec<DnsQueryResponse>,
+    pub results: Vec<ResourceRecord>,
 }
 
 impl EnumerationOutput {
@@ -16,7 +16,7 @@ impl EnumerationOutput {
         }
     }
 
-    pub fn add_result(&mut self, result: DnsQueryResponse) {
+    pub fn add_result(&mut self, result: ResourceRecord) {
         self.results.push(result);
     }
 

--- a/src/io/packet_buffer.rs
+++ b/src/io/packet_buffer.rs
@@ -56,6 +56,15 @@ impl PacketBuffer {
         Ok(())
     }
 
+    pub fn set_u16(&mut self, pos: usize, val: u16) -> Result<()> {
+        if pos + 1 >= self.buf.len() {
+            return Err(anyhow!("Position out of bounds"));
+        }
+        self.buf[pos] = (val >> 8) as u8;
+        self.buf[pos + 1] = u8::try_from(val)?;
+        Ok(())
+    }
+
     pub fn read_u8(&mut self) -> Result<u8> {
         if self.pos >= self.buf.len() {
             return Err(anyhow!("End of buffer"));


### PR DESCRIPTION
This pull request includes significant changes to the DNS resolver and related modules to improve the handling and representation of DNS query responses. The changes involve replacing the `DnsQueryResponse` type with `DnsPacket` and `ResourceRecord` throughout the codebase, updating function signatures, and modifying how DNS records are processed and displayed.

### Changes to DNS Resolver:

* [`src/dns/resolver.rs`](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aL47-R47): Updated the `resolve_domain` function to return a `DnsPacket` instead of a `Vec<DnsQueryResponse>`. Modified the function to handle the new return type appropriately. [[1]](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aL47-R47) [[2]](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aL64-R64)
* [`src/dns/resolver.rs`](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aL202-R202): Updated test cases to reflect changes in the DNS query response structure.

### Changes to Protocol and Data Structures:

* [`src/io/json.rs`](diffhunk://#diff-e5f26341c9a5460f8bfe4adf7be34192d9289d13dfaf1243fd04dbbb2331d8bdL1-R8): Replaced `DnsQueryResponse` with `ResourceRecord` in the `EnumerationOutput` struct and its methods. [[1]](diffhunk://#diff-e5f26341c9a5460f8bfe4adf7be34192d9289d13dfaf1243fd04dbbb2331d8bdL1-R8) [[2]](diffhunk://#diff-e5f26341c9a5460f8bfe4adf7be34192d9289d13dfaf1243fd04dbbb2331d8bdL19-R19)
* [`src/io/packet_buffer.rs`](diffhunk://#diff-9e433a20e88d80ecae34e947134c95401d85037fc2500e3d2150e70cc9d88030R59-R67): Added a new method `set_u16` to the `PacketBuffer` struct for setting a 16-bit unsigned integer at a specified position.

### Changes to DNS Enumeration:

* [`src/modes/basic_enumerator.rs`](diffhunk://#diff-739467d5bec7f0fe0f93bc3fa11a84df1d21d3c8488a9298024ae96fb9f0825aL6-R6): Updated various functions to use `ResourceRecord` instead of `DnsQueryResponse`. Modified sorting and processing logic to handle the new data structure. [[1]](diffhunk://#diff-739467d5bec7f0fe0f93bc3fa11a84df1d21d3c8488a9298024ae96fb9f0825aL6-R6) [[2]](diffhunk://#diff-739467d5bec7f0fe0f93bc3fa11a84df1d21d3c8488a9298024ae96fb9f0825aL45-R48) [[3]](diffhunk://#diff-739467d5bec7f0fe0f93bc3fa11a84df1d21d3c8488a9298024ae96fb9f0825aL72-R74) [[4]](diffhunk://#diff-739467d5bec7f0fe0f93bc3fa11a84df1d21d3c8488a9298024ae96fb9f0825aL88-R96) [[5]](diffhunk://#diff-739467d5bec7f0fe0f93bc3fa11a84df1d21d3c8488a9298024ae96fb9f0825aL120-R129) [[6]](diffhunk://#diff-739467d5bec7f0fe0f93bc3fa11a84df1d21d3c8488a9298024ae96fb9f0825aL143-R192)

### Changes to Subdomain Enumerator:

* [`src/modes/subdomain_enumerator.rs`](diffhunk://#diff-6abb81cfed116dfb65ffc8a9535553138b01cdf3a56207cb77ceac33715d27f7R10-R13): Updated the `EnumerationContext` struct and related functions to use `ResourceRecord` instead of `DnsQueryResponse`. Adjusted the logic for processing and displaying DNS query results. [[1]](diffhunk://#diff-6abb81cfed116dfb65ffc8a9535553138b01cdf3a56207cb77ceac33715d27f7R10-R13) [[2]](diffhunk://#diff-6abb81cfed116dfb65ffc8a9535553138b01cdf3a56207cb77ceac33715d27f7L22-R24) [[3]](diffhunk://#diff-6abb81cfed116dfb65ffc8a9535553138b01cdf3a56207cb77ceac33715d27f7L140-R141) [[4]](diffhunk://#diff-6abb81cfed116dfb65ffc8a9535553138b01cdf3a56207cb77ceac33715d27f7L160-R161) [[5]](diffhunk://#diff-6abb81cfed116dfb65ffc8a9535553138b01cdf3a56207cb77ceac33715d27f7L220-R221) [[6]](diffhunk://#diff-6abb81cfed116dfb65ffc8a9535553138b01cdf3a56207cb77ceac33715d27f7L244-R245) [[7]](diffhunk://#diff-6abb81cfed116dfb65ffc8a9535553138b01cdf3a56207cb77ceac33715d27f7L348-R391)