### PR TITLE
v0.10.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,3 +219,98 @@ jobs:
           asset_path: ./${{ env.ASSET_NAME }}
           asset_name: ${{ env.ASSET_NAME }}
           asset_content_type: application/octet-stream
+
+  build_and_publish_docker:
+    needs: create_release
+    name: Build and Publish Docker Images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Extract version
+        id: version
+        run: |
+          VERSION="${{ needs.create_release.outputs.version }}"
+          VERSION_NO_V=${VERSION#v}
+          echo "version_no_v=${VERSION_NO_V}" >> $GITHUB_OUTPUT
+          
+          # Extract major and minor versions
+          MAJOR=$(echo ${VERSION_NO_V} | cut -d. -f1)
+          MINOR=$(echo ${VERSION_NO_V} | cut -d. -f2)
+          echo "major=${MAJOR}" >> $GITHUB_OUTPUT
+          echo "major_minor=${MAJOR}.${MINOR}" >> $GITHUB_OUTPUT
+
+      - name: Build and push basic Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile.basic
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/reccedns:${{ steps.version.outputs.version_no_v }}
+            ghcr.io/${{ github.repository_owner }}/reccedns:${{ steps.version.outputs.major_minor }}
+            ghcr.io/${{ github.repository_owner }}/reccedns:${{ steps.version.outputs.major }}
+            ghcr.io/${{ github.repository_owner }}/reccedns:latest
+          labels: |
+            org.opencontainers.image.title=RecceDNS
+            org.opencontainers.image.description=DNS Enumeration and Information Gathering Tool
+            org.opencontainers.image.version=${{ steps.version.outputs.version_no_v }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build and push lists Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile.lists
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/reccedns:${{ steps.version.outputs.version_no_v }}-lists
+            ghcr.io/${{ github.repository_owner }}/reccedns:${{ steps.version.outputs.major_minor }}-lists
+            ghcr.io/${{ github.repository_owner }}/reccedns:${{ steps.version.outputs.major }}-lists
+            ghcr.io/${{ github.repository_owner }}/reccedns:lists
+          labels: |
+            org.opencontainers.image.title=RecceDNS with SecLists
+            org.opencontainers.image.description=DNS Enumeration and Information Gathering Tool with SecLists DNS wordlists included
+            org.opencontainers.image.version=${{ steps.version.outputs.version_no_v }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Update release notes with Docker information
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ needs.create_release.outputs.version }}
+          append_body: true
+          body: |
+            ## Docker Images
+            
+            Docker images are available on GitHub Container Registry:
+            
+            ### Basic Image
+            Container with the RecceDNS tool only. Mount wordlists for subdomain enumeration via a bind or volume mount.
+            ```
+            docker pull ghcr.io/${{ github.repository_owner }}/reccedns:${{ steps.version.outputs.version_no_v }}
+            docker pull ghcr.io/${{ github.repository_owner }}/reccedns:latest
+            ```
+            
+            ### Image with SecLists
+            Container with the RecceDNS tool and the SecLists DNS wordlists included. Use the `lists` tag to pull this image.
+            ```
+            docker pull ghcr.io/${{ github.repository_owner }}/reccedns:${{ steps.version.outputs.version_no_v }}-lists
+            docker pull ghcr.io/${{ github.repository_owner }}/reccedns:lists
+            ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
             platform_name: mac-x86_64
           - os: macos-latest
             target: aarch64-apple-darwin
-            platform_name: mac-arm64
+            platform_name: mac-aarch64
 
     steps:
       - name: Checkout repository

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "reccedns"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reccedns"
 authors = ["Alex Ogden"]
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM rust:bullseye-slim as builder
+
+WORKDIR /app
+COPY . .
+
+# Install build dependencies for Debian
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cargo build --release --locked
+
+
+# RUNTIME STAGE
+FROM debian:bullseye-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    libssl1.1 \
+    ca-certificates \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user
+RUN useradd -m reccedns
+
+# Copy only the binary
+COPY --from=builder /app/target/release/reccedns /usr/local/bin/
+
+# Switch to non-root user
+USER reccedns
+
+# Create volume mount point for wordlists and data
+VOLUME ["/wordlists", "/data"]
+WORKDIR /data
+
+ENTRYPOINT ["reccedns"]
+CMD ["--help"]

--- a/Dockerfile.basic
+++ b/Dockerfile.basic
@@ -1,0 +1,40 @@
+FROM rust:slim-bullseye as builder
+
+WORKDIR /app
+COPY . .
+
+# Install build dependencies for Debian
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cargo build --release --locked
+
+
+# RUNTIME STAGE
+FROM debian:bullseye-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    libssl1.1 \
+    ca-certificates \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a non-root user
+RUN useradd -m reccedns
+
+# Copy only the binary
+COPY --from=builder /app/target/release/reccedns /usr/local/bin/
+
+# Switch to non-root user
+USER reccedns
+
+# Create volume mount point for wordlists and data
+VOLUME ["/wordlists", "/data"]
+WORKDIR /data
+
+ENTRYPOINT ["reccedns"]
+CMD ["--help"]

--- a/Dockerfile.lists
+++ b/Dockerfile.lists
@@ -1,14 +1,14 @@
-FROM rust:bullseye-slim as builder
+FROM rust:slim-bullseye as builder
 
 WORKDIR /app
 COPY . .
 
 # Install build dependencies for Debian
 RUN apt-get update && apt-get install -y \
-    pkg-config \
-    libssl-dev \
-    --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+	pkg-config \
+	libssl-dev \
+	--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
 
 RUN cargo build --release --locked
 
@@ -18,10 +18,18 @@ FROM debian:bullseye-slim
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
-    libssl1.1 \
-    ca-certificates \
-    --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+	libssl1.1 \
+	ca-certificates \
+	git \
+	--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Download SecLists DNS subdomain wordlists
+RUN mkdir -p /opt/wordlists && \
+	git clone --depth 1 https://github.com/danielmiessler/SecLists.git /tmp/SecLists && \
+	cp -r /tmp/SecLists/Discovery/DNS/* /opt/wordlists/ && \
+	rm -rf /tmp/SecLists && \
+	chmod -R 755 /opt/wordlists
 
 # Create a non-root user
 RUN useradd -m reccedns

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ To clone the repository and build the software, follow these steps:
 
 1. **Clone the repository**:
 	```sh
-	git clone git@github.com:AlexOgden/RecceDNS.git
+	git clone --depth 1 git@github.com:AlexOgden/RecceDNS.git
 	cd reccedns
 	```
 

--- a/src/dns/format.rs
+++ b/src/dns/format.rs
@@ -70,14 +70,13 @@ pub fn create_query_response_string(query_result: &HashSet<ResourceRecord>) -> S
     }
 
     // Prepare the final formatted output
-    let formatted_domains: Vec<String> = domain_map
+    let mut formatted_domains: Vec<String> = domain_map
         .iter()
         .map(|(domain, records)| {
             let mut formatted_records: Vec<String> = records
                 .iter()
                 .map(|(record_type, data_set)| {
-                    let mut sorted_data: Vec<&str> =
-                        data_set.iter().map(std::string::String::as_str).collect();
+                    let mut sorted_data: Vec<&str> = data_set.iter().map(AsRef::as_ref).collect();
                     sorted_data.sort_unstable();
                     format!("    {}: [{}]", record_type, sorted_data.join(", "))
                 })
@@ -86,6 +85,9 @@ pub fn create_query_response_string(query_result: &HashSet<ResourceRecord>) -> S
             format!("  {}:\n{}", domain, formatted_records.join("\n"))
         })
         .collect();
+
+    // Sort domains for consistent output
+    formatted_domains.sort();
 
     format!("\n{}", formatted_domains.join("\n\n"))
 }

--- a/src/dns/resolver.rs
+++ b/src/dns/resolver.rs
@@ -217,15 +217,14 @@ fn build_dns_query(
 
     // Convert IP address to PTR format if needed
     let domain = if query_type == &QueryType::PTR {
-        // Try parsing as IPv4 first
-        domain.parse::<Ipv4Addr>().map_or_else(
-            |_| {
-                domain
-                    .parse::<Ipv6Addr>()
-                    .map_or_else(|_| domain.to_owned(), |ipv6| ipv6_to_ptr(&ipv6))
-            },
-            ipv4_to_ptr,
-        )
+        #[allow(clippy::option_if_let_else)]
+        if let Ok(ipv4) = domain.parse::<Ipv4Addr>() {
+            ipv4_to_ptr(ipv4)
+        } else if let Ok(ipv6) = domain.parse::<Ipv6Addr>() {
+            ipv6_to_ptr(&ipv6)
+        } else {
+            domain.to_owned()
+        }
     } else {
         domain.to_owned()
     };

--- a/src/dns/resolver.rs
+++ b/src/dns/resolver.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result};
 use rand::Rng;
 use std::io::{Read, Write};
 use std::net::{Ipv4Addr, Ipv6Addr, TcpStream, UdpSocket};
-use std::sync::Arc;
 use std::time::Duration;
 
 use crate::dns::{
@@ -14,19 +13,19 @@ use crate::network::types::TransportProtocol;
 
 const DNS_PORT: u8 = 53;
 const UDP_BUFFER_SIZE: usize = 512;
+const TIMEOUT: std::time::Duration = Duration::from_secs(1);
 
-fn initialize_udp_socket() -> Result<Arc<UdpSocket>> {
+fn initialize_udp_socket() -> Result<UdpSocket> {
     let socket = UdpSocket::bind("0.0.0.0:0")?;
-    let timeout = Duration::from_millis(1750);
 
     socket
-        .set_read_timeout(Some(timeout))
+        .set_read_timeout(Some(TIMEOUT))
         .context("Failed to set read timeout")?;
     socket
-        .set_write_timeout(Some(timeout))
+        .set_write_timeout(Some(TIMEOUT))
         .context("Failed to set write timeout")?;
 
-    Ok(Arc::new(socket))
+    Ok(socket)
 }
 
 pub fn resolve_domain(
@@ -36,31 +35,35 @@ pub fn resolve_domain(
     transport_protocol: &TransportProtocol,
     recursion: bool,
 ) -> Result<DnsPacket, DnsError> {
-    let udp_socket =
-        initialize_udp_socket().map_err(|error| DnsError::Network(error.to_string()))?;
+    let socket = initialize_udp_socket()
+        .map_err(|e| DnsError::Network(format!("Failed to create socket: {e}")))?;
 
-    let query_result = execute_dns_query(
-        &udp_socket,
+    let result = execute_dns_query(
+        &socket,
         transport_protocol,
         dns_resolver,
         domain,
         query_type,
         recursion,
-    )?;
+    );
 
-    match query_result.header.rescode {
-        ResultCode::NOERROR => {
-            if query_result.answers.is_empty() {
-                Err(DnsError::NoRecordsFound)
-            } else {
-                Ok(query_result)
+    // Process the result
+    match result {
+        Ok(query_result) => match query_result.header.rescode {
+            ResultCode::NOERROR => {
+                if query_result.answers.is_empty() {
+                    Err(DnsError::NoRecordsFound)
+                } else {
+                    Ok(query_result)
+                }
             }
-        }
-        ResultCode::NXDOMAIN => Err(DnsError::NonExistentDomain),
-        ResultCode::SERVFAIL => Err(DnsError::NameserverError("Server Failed".to_owned())),
-        ResultCode::NOTIMP => Err(DnsError::NameserverError("Not Implemented".to_owned())),
-        ResultCode::REFUSED => Err(DnsError::NameserverError("Refused".to_owned())),
-        ResultCode::FORMERR => Err(DnsError::ProtocolData("Format Error".to_owned())),
+            ResultCode::NXDOMAIN => Err(DnsError::NonExistentDomain),
+            ResultCode::SERVFAIL => Err(DnsError::NameserverError("Server Failed".to_owned())),
+            ResultCode::NOTIMP => Err(DnsError::NameserverError("Not Implemented".to_owned())),
+            ResultCode::REFUSED => Err(DnsError::NameserverError("Refused".to_owned())),
+            ResultCode::FORMERR => Err(DnsError::ProtocolData("Format Error".to_owned())),
+        },
+        Err(e) => Err(e),
     }
 }
 
@@ -87,7 +90,7 @@ fn execute_dns_query(
 
     let parsed_response = parse_dns_response(&response)?;
 
-    // Verify the response ID matches our query ID to prevent spoofing
+    // Verify the response ID matches our query ID to prevent spoofing/detect network issues
     if parsed_response.header.id != query_id {
         return Err(DnsError::InvalidData(format!(
             "Response ID {} does not match query ID {} for domain '{}'",
@@ -137,7 +140,6 @@ fn send_query_udp(socket: &UdpSocket, query: &[u8], dns_server: &str) -> Result<
         )));
     }
 
-    // Create a properly sized response buffer
     Ok(response_buffer[..bytes_received].to_vec())
 }
 
@@ -149,12 +151,11 @@ fn send_query_tcp(query: &[u8], dns_server: &str) -> Result<Vec<u8>, DnsError> {
         .map_err(|e| DnsError::Network(format!("Failed to connect to {dns_server} (TCP): {e}")))?;
 
     // Set read and write timeouts
-    let timeout = Duration::from_secs(3);
     stream
-        .set_read_timeout(Some(timeout))
+        .set_read_timeout(Some(TIMEOUT))
         .map_err(|e| DnsError::Network(format!("Failed to set read timeout: {e}")))?;
     stream
-        .set_write_timeout(Some(timeout))
+        .set_write_timeout(Some(TIMEOUT))
         .map_err(|e| DnsError::Network(format!("Failed to set write timeout: {e}")))?;
 
     // Send query length in big-endian format
@@ -229,7 +230,7 @@ fn build_dns_query(
         domain.to_owned()
     };
 
-    // Build the query packet
+    // Build the query packet with thread-safe random ID
     let mut packet = DnsPacket::new();
     packet.header.id = rand::rng().random();
     packet.header.questions = 1;

--- a/src/modes/subdomain_enumerator.rs
+++ b/src/modes/subdomain_enumerator.rs
@@ -53,8 +53,7 @@ struct WorkerParams {
 }
 
 // Default query types for subdomain enumeration if none provided.
-const DEFAULT_QUERY_TYPES: &[QueryType] =
-    &[QueryType::A, QueryType::AAAA, QueryType::MX, QueryType::TXT];
+const DEFAULT_QUERY_TYPES: &[QueryType] = &[QueryType::A, QueryType::AAAA];
 
 #[allow(clippy::too_many_lines)]
 pub fn enumerate_subdomains(cmd_args: &CommandArgs, dns_resolver_list: &[&str]) -> Result<()> {


### PR DESCRIPTION
This pull request includes significant updates to the build and deployment process, as well as some code improvements and bug fixes. The most important changes involve adding a new job for building and publishing Docker images, updating the version, and making various improvements to the DNS resolver code.

### Build and Deployment Improvements:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R222-R316): Added a new job `build_and_publish_docker` to build and publish Docker images for the project. This includes setting up Docker Buildx, logging into GitHub Container Registry, extracting version information, building and pushing Docker images, and updating release notes with Docker information.
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L4-R4): Updated the project version from `0.10.1` to `0.10.2`.
* [`Dockerfile.basic`](diffhunk://#diff-8fec1055411de5665790f0a849d33ba69231aef2c6854f1eeea2bd9d2e4e3074R1-R40): Added a new Dockerfile for building a basic Docker image with the RecceDNS tool.
* [`Dockerfile.lists`](diffhunk://#diff-9086fcb2718b24aa5d383d5b5a3ea47e6e964702c2c97f3361c36b87d5b29a72R1-R48): Added a new Dockerfile for building a Docker image with the RecceDNS tool and SecLists DNS wordlists included.

### Code Improvements:
* [`src/dns/format.rs`](diffhunk://#diff-a2a9aa108201a3b7caf64a035a54e16c83ac3abf384b7e13d443c6bf646d876eL73-R79): Improved the `create_query_response_string` function by sorting domains for consistent output and using `AsRef` for mapping data. [[1]](diffhunk://#diff-a2a9aa108201a3b7caf64a035a54e16c83ac3abf384b7e13d443c6bf646d876eL73-R79) [[2]](diffhunk://#diff-a2a9aa108201a3b7caf64a035a54e16c83ac3abf384b7e13d443c6bf646d876eR89-R91)
* [`src/dns/resolver.rs`](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aL5): Refactored the DNS resolver code to improve error handling, remove the use of `Arc` for `UdpSocket`, and use a constant for timeout duration. [[1]](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aL5) [[2]](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aR16-R28) [[3]](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aL39-R52) [[4]](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aR65-R66) [[5]](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aL90-R93) [[6]](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aL140) [[7]](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aL152-R158) [[8]](diffhunk://#diff-a0e5e4fedc76e99c5f04ffcdcb4728c6b045d210986d21a27d6e8a3049777a8aL219-R232)

### Documentation Update:
* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L40-R40): Updated the clone command to use `--depth 1` for a shallow clone.

### Miscellaneous:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L81-R81): Corrected the platform name from `mac-arm64` to `mac-aarch64`.
* [`src/modes/subdomain_enumerator.rs`](diffhunk://#diff-6abb81cfed116dfb65ffc8a9535553138b01cdf3a56207cb77ceac33715d27f7L56-R56): Updated the default query types for subdomain enumeration to include only `A` and `AAAA` record types.