### PR TITLE
v0.12.0

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Tests
 
 on:
   push:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "atomic-waker"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,9 +135,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "shlex",
 ]
@@ -156,9 +156,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -779,9 +779,9 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -819,9 +819,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -1218,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1992,9 +1992,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,9 +427,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -773,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1025,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -1049,13 +1049,12 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha",
  "rand_core",
- "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "reccedns"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reccedns"
 authors = ["Alex Ogden"]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.11.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.97"
+anyhow = "1.0.98"
 clap = { version = "4.5.34", features = ["derive"] }
 colored = "3.0.0"
 ctrlc = "3.4.5"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,14 @@
-# RecceDNS 
+<p align="center">
+	<h1 align="center" style="font-size:3em;">RecceDNS</h1>
+</p>
+<p align="center">
+	<a title="Build Status" target="_blank" href="https://github.com/AlexOgden/RecceDNS/actions/workflows/cargo_test.yml"><img src="https://img.shields.io/github/actions/workflow/status/tursodatabase/limbo/rust.yml?style=flat-square"></a>
+	<a title="Latest Release" target="_blank" href="https://github.com/AlexOgden/RecceDNS/releases/latest"><img src="https://img.shields.io/github/v/release/AlexOgden/RecceDNS?style=flat-square&color=aqua"></a>
+	<a title="GitHub Commits" target="_blank" href="https://github.com/AlexOgden/RecceDNS/commits/main"><img src="https://img.shields.io/github/commit-activity/m/AlexOgden/RecceDNS.svg?style=flat-square"></a>
+	<a title="Last Commit" target="_blank" href="https://github.com/AlexOgden/RecceDNS/commits/main"><img src="https://img.shields.io/github/last-commit/AlexOgden/RecceDNS.svg?style=flat-square&color=FF9900"></a>
+</p>
+
+---
 
 RecceDNS is a DNS enumeration/OSINT tool written in Rust 
 that provides functionality to gather information about domain names. It performs various DNS queries to discover subdomains, IP addresses, and other DNS records associated with a target domain. The tool is designed to be fast, efficient, and easy to use. This tool places emphasis on high-performance subdomain bruteforcing with advanced functionality for rapid enumeration and rate limiting mitigation.
@@ -32,9 +42,10 @@ I originally started working on this project to learn Rust, improve on network p
 	- Adaptive delay (increases and decreases dynamically within bounds to reduce rate-limiting).
 	- Asyncronous UDP socket pooling - thousands of queries without locking up file resources.
 
-## Installation
+## Getting Started
 
-### Cloning and Building
+<details>
+<summary>🔨 Cloning and Building from Source</summary>
 
 To clone the repository and build the software, follow these steps:
 
@@ -58,176 +69,188 @@ To clone the repository and build the software, follow these steps:
 
 After building, you can find the executable in the `target/release` directory.
 
-### Pre-Built Binaries
+</details>
 
-Pre-built binaries are available in the releases section for the following platforms:
+<details>
+<summary>📦 Pre-Built Binaries</summary>
+
+Pre-built binaries are available in the [releases](https://github.com/AlexOgden/RecceDNS/releases) section for the following platforms:
 
 - Windows (x86_64)
 - macOS (x86_64, arm64)
 - Linux (x86_64, arm64, armv7)
 
-You can download these binaries directly from the releases page without having to build from source.
+You can download these binaries directly from the releases page without building from source.
 
-### Docker
+</details>
+<details>
+<summary>🐳 Docker Images</summary>
 
-Docker images are also available to use. See the releases for the latest versions.
+Official Docker images are available:
 
-Two images are provided:
+- **Basic**: Minimal image with only RecceDNS installed.
+- **Lists**: Includes RecceDNS and pre-installed DNS subdomain lists from [SecLists](https://github.com/danielmiessler/SecLists) in `/opt/wordlists`.
 
-- Basic: comes installed only with the RecceDNS application. Minimal image size.
-- Lists: contains pre-installed with the latest DNS subdomain lists from [SecLists](https://github.com/danielmiessler/SecLists) located in the `/opt/wordlists` directory.
+**Usage Examples:**
 
-**Usage:**
-
-Basic
+Basic image:
 ```sh
 docker pull ghcr.io/alexogden/reccedns:latest
 docker run --rm -it ghcr.io/alexogden/reccedns:latest -m c -d 1.1.1.1 -t github.com
 ```
 
-Lists
+Lists image:
 ```sh
 docker pull ghcr.io/alexogden/reccedns:lists
 docker run --rm -it ghcr.io/alexogden/reccedns:lists -m s -t github.com -w /opt/wordlists/list.txt -D A:10-50 -d 1.1.1.1
 ```
 
+See the [releases](https://github.com/AlexOgden/RecceDNS/releases) page for the latest versions.
+</details>
+
 ## Arguments
 
-- `-m, --mode <MODE>`: The operation mode to run, bruteforce subdomains or enumerate records. Possible values are:
-  - `b`: Basic Enumeration
-  - `s`: Subdomain Enumeration
-  - `r`: Reverse PTR IP
-  - `c`: Certificate Search
-  - `t`: TLD Expansion
+| Argument | Description |
+|----------|-------------|
+| `-m, --mode <MODE>` | **Operation mode**. Possible values:<br>• `b`: Basic Enumeration<br>• `s`: Subdomain Enumeration<br>• `r`: Reverse PTR IP<br>• `c`: Certificate Search<br>• `t`: TLD Expansion |
+| `-t, --target <TARGET>` | **Target base domain or IP** (single, CIDR, or range).<br>Examples: `google.com`, `192.168.2.3`, `192.168.2.0/24`, `192.168.2.1-192.168.2.230` |
+| `-d, --dns-resolvers <DNS_RESOLVERS>` | **DNS resolver(s)** (IPv4, comma-separated).<br>Default: `1.1.1.1`.<br>Multiple resolvers can be selected randomly or sequentially (see `-r`). |
+| `-p, --protocol <TRANSPORT_PROTOCOL>` | *(Optional)* **Transport protocol** for DNS queries.<br>Values: `UDP` (default), `TCP` |
+| `-w, --wordlist <WORDLIST>` | **Path to subdomain wordlist**. Required for enumeration mode. |
+| `-v, --verbose` | Print extra information. Default: `false` |
+| `-q, --query-types <QUERY_TYPE>` | **Resource-record(s) to query**.<br>Values: `A`, `AAAA`, `CNAME`, `MX`, `TXT`, `NS`, `SOA`, `SRV`, `ANY` (default).<br>Comma-separated list. Not all types available in every mode. |
+| `--no-welcome` | Don't show the welcome ASCII art. |
+| `--no-dns-check` | Don't check if DNS servers are working before starting. |
+| `--no-recursion` | Set recursion-desired to false in DNS queries. |
+| `--no-retry` | Don't retry failed queries. |
+| `--no-print-records` | Don't print DNS records in subdomain enumeration (show only subdomains). |
+| `--no-query-stats` | Don't calculate/print average query time. |
+| `--no-print-errors` | Don't print failed queries during subdomain enumeration (errors still show on retry). Use `-Q` to silence all output. |
+| `--show-resolver` | Print which resolver was used for each query. |
+| `-D, --delay <MS\|RANGE\|ADAPTIVE>` | **Delay between queries** (subdomain enumeration).<br>• Fixed: <code>1000</code> (ms)<br>• Range: <code>100-200</code> (random ms)<br>• Adaptive: <code>A</code> or <code>A:10-750</code> (dynamic, <code>A</code> alone uses <code>10-500</code> as the default range) |
+| `-r, --use-random` | When multiple resolvers are provided, randomly select one for each query. |
+| `--json <path>` | Output results to a JSON file. `.json` will be appended if not provided. |
+| `-Q, --quiet` | Don't print any results to the terminal. Useful for large targets when outputting to JSON. |
+| `-T, --threads <N>` | Number of threads for subdomain enumeration.<br>Defaults to (logical cores - 1), max 6 if more than 6 cores. |
 
-- `-t, --target <TARGET>`: The target base domain name or IP address (single, CIDR, or range). Examples: `google.com`, `192.168.2.3`, `192.168.2.0/24`, `192.168.2.1-192.168.2.230`.
-
-- `-d, --dns-resolvers <DNS_RESOLVERS>`: IPv4 Address of the DNS resolver(s) to use (comma-separated). Multiple resolvers will be selected either randomly or sequentially based on the presence of `-r`. Default is `1.1.1.1`.
-
-- `-p, --protocol <TRANSPORT_PROTOCOL>`: *OPTIONAL*: Transport protocol to use for DNS queries. Possible values are:
-  - `UDP`: **(default)**
-  - `TCP`
-
-- `-w, --wordlist <WORDLIST>`: Path to subdomain wordlist. Required for enumeration mode.
-
-- `-v, --verbose`: Print extra information. Default is `false`.
-
-- `-q, --query-types <QUERY_TYPE>`: What resource-record(s) to query. Possible values are: `A`, `AAAA`, `CNAME`, `MX`, `TXT`, `NS`, `SOA`, `SRV`, `ANY` (default). Accepts a comma-seperated list. Not every query type is available for each mode.
-
-- `--no-welcome`: Don't show the welcome ASCII art.
-
-- `--no-dns-check`: Don't check if the DNS servers are working before starting.
-
-- `--no-recursion`: Sets recursion-desired to false in DNS queries.
-
-- `--no-retry`: Don't retry failed queries.
-
-- `--no-print-records`: Don't print the DNS records in subdomain enumeration, only show the subdomains.
-
-- `--no-query-stats`: Don't calculate and print the average query time.
-
-- `--no-print-errors`: Don't print failed queries during subdomain enumeration. Errors will still show when failed queries are retried. To silence all output, use `-Q`.
-
-- `--show-resolver`: Print which resolver was used for each query.
-
-- `-D` `--delay <MS|RANGE|ADAPTIVE>`: Delay in milliseconds to use between queries in subdomain enumeration. You can specify a fixed value (e.g., `1000` for a 1-second delay) or a range (e.g., `100-200` for a random delay between 100 and 200 milliseconds), or use the dynamic adaptive mode: default `A` or specify a min and max: `A:10-750`.
-
-- `-r` `--use-random`: When multiple resolvers are provided, randomly select from the list on each query in enumeration.
-
-- `--json <path>` : Output the results to a JSON file. '.json' will be appended as the extension is not provided.
-
-- `-Q` `--quiet` : Don't print any results to the terminal. Can be useful for targets with large amount of results that you are outputing to JSON.
-
-- `-T` `--threads` : Number of threads to use for subdomain enumeration. Defaults to (logical cores - 1), however if cores is greater than 6 it will default to 6.
 
 ## Example Usage
 
 ### Basic Enumeration
 
-`reccedns -m b -d 1.1.1.1 -t github.com`
+```sh
+reccedns -m b -d 1.1.1.1 -t github.com
+```
 
 ### Bruteforce Subdomains
 
-Any Records
+**Any Records**
+```sh
+reccedns -m s -d 1.1.1.1 -w .\subdomains-top1million-5000.txt -t github.com
+```
 
-`reccedns -m s -d 1.1.1.1 -w .\subdomains-top1million-5000.txt -t github.com`
+**A (IPv4) Only**
+```sh
+reccedns -m s -d 1.1.1.1 -q a -w .\subdomains-top1million-5000.txt -t github.com
+```
 
-A (IPv4) Only
+**SRV Enumeration**
+```sh
+reccedns -m s -d 1.1.1.1 -q srv -w .\srv_names.txt -t github.com
+```
 
-`reccedns -m s -d 1.1.1.1 -q a -w .\subdomains-top1million-5000.txt -t github.com`
+**Multiple Resolvers - Sequential Selection**
+```sh
+reccedns -m s -d 1.1.1.1,9.9.9.9,8.8.8.8 -q a,aaaa -w .\subdomains-top1million-5000.txt -t github.com
+```
 
-SRV enumeration
+**Multiple Resolvers - Random Selection**
+```sh
+reccedns -m s -d 1.1.1.1,9.9.9.9,8.8.8.8 --use-random --show-resolver -q a -w .\subdomains-top1million-5000.txt -t github.com
+```
 
-`reccedns -m s -d 1.1.1.1 -q srv -w .\srv_names.txt -t github.com`
+**With Consistent Delay**
+```sh
+reccedns -m s -d 1.1.1.1 -w .\subdomains-top1million-5000.txt -t github.com --delay 50
+```
 
-Multiple Resolvers - Sequential Selection
+**With Random-Range Delay**
+```sh
+reccedns -m s -d 1.1.1.1 -w .\subdomains-top1million-5000.txt -t github.com --delay 50-900
+```
 
-`reccedns -m s -d 1.1.1.1,9.9.9.9,8.8.8.8 -q a,aaaa -w .\subdomains-top1million-5000.txt -t github.com`
+**With Adaptive Delay**
+```sh
+reccedns -m s -d 1.1.1.1 -w .\subdomains-top1million-5000.txt -t github.com --delay A:5-750
+```
 
-Multiple Resolvers - Random Selection
+**With Specified Thread Count**
+```sh
+reccedns -m s -d 1.1.1.1 -w .\subdomains-top1million-5000.txt -t github.com -T 6
+```
 
-`reccedns -m s -d 1.1.1.1,9.9.9.9,8.8.8.8 --use-random ---show-resolver -q a -w .\subdomains-top1million-5000.txt -t github.com`
+**Output to JSON**
+```sh
+reccedns -m s -d 1.1.1.1 -w .\combined_names.txt -t github.com -T 6 -q A,AAAA,MX --json query_output
+```
 
-With consistent delay
+**Don't Print Errors During Enumeration (still prints on retry)**
+```sh
+reccedns -m s -d 8.8.8.8 -w .\combined_names -t github.com -T 4 --no-print-errors
+```
 
-`reccedns -m s -d 1.1.1.1 -w .\subdomains-top1million-5000.txt -t github.com --delay 50`
-
-With random-range delay
-
-`reccedns -m s -d 1.1.1.1 -w .\subdomains-top1million-5000.txt -t github.com --delay 50-900`
-
-With adaptive delay
-
-`reccedns -m s -d 1.1.1.1 -w .\subdomains-top1million-5000.txt -t github.com --delay A:5-750`
-
-With specified thread count
-
-`reccedns -m s -d 1.1.1.1 -w .\subdomains-top1million-5000.txt -t github.com -T 6`
-
-Output to JSON
-
-`reccedns -m s -d 1.1.1.1 -w .\combined_names.txt -t github.com -T 6 -q A,AAAA,MX --json query_output`
-
-Don't print errors during enumeration (still prints on retry)
-
-`reccedns -m s -d 8.8.8.8 -w .\combined_names -t github.com -T 4 --no-print-errors`
+---
 
 ### Reverse PTR IP Search
 
-Single IP Address
+**Single IP Address**
+```sh
+reccedns -m r -d 1.1.1.1 -t 192.168.0.1
+```
 
-`reccedns -m r -d 1.1.1.1 -t 192.168.0.1`
+**CIDR Notation**
+```sh
+reccedns -m r -d 1.1.1.1 -t 192.168.0.0/24
+```
 
-CIDR Notation
+**IP Range**
+```sh
+reccedns -m r -d 1.1.1.1 -t 192.168.0.0-192.168.1.254
+```
 
-`reccedns -m r -d 1.1.1.1 -t 192.168.0.0/24`
-
-IP Range
-
-`reccedns -m r -d 1.1.1.1 -t 192.168.0.0-192.168.1.254`
+---
 
 ### Certificate Search
 
-`reccedns -m c -t github.com`
+```sh
+reccedns -m c -t github.com
+```
+
+---
 
 ### TLD Expansion
 
-Check 'github' with the full list of IANA TLDs
+**Check 'github' with the full list of IANA TLDs**
+```sh
+reccedns -m t -d 8.8.8.8 -t github.com
+```
 
-`reccedns -m t -d 8.8.8.8 -t github.com`
+**Don't Print the Actual DNS Records**
+```sh
+reccedns -m t -d 8.8.8.8 -t github.com --no-print-records
+```
 
-Don't print the actual DNS records
+**Only Check Using `A` Records**
+```sh
+reccedns -m t -d 8.8.8.8 -t github.com -q a
+```
 
-`reccedns -m t -d 8.8.8.8 -t github.com --no-print-records`
+**Check with `A` and `AAAA`**
+```sh
+reccedns -m t -d 8.8.8.8 -t github.com -q a,aaaa
+```
 
-Only check using `A` records
-
-`reccedns -m t -d 8.8.8.8 -t github.com -q a`
-
-Check with `A` and `AAAA`
-
-`reccedns -m t -d 8.8.8.8 -t github.com -q a,aaaa`
-
-Provide a wordlist with TLDs
-
-`reccedns -m t -d 8.8.8.8 -t github.com -w tlds.txt`
+**Provide a Wordlist with TLDs**
+```sh
+reccedns -m t -d 8.8.8.8 -t github.com -w tlds.txt
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # RecceDNS 
 
 RecceDNS is a DNS enumeration/OSINT tool written in Rust 
-that provides functionality to gather information about domain names. It performs various DNS queries to discover subdomains, IP addresses, and other DNS records associated with a target domain. The tool is designed to be fast, efficient, and easy to use, leveraging the performance benefits of Rust.
+that provides functionality to gather information about domain names. It performs various DNS queries to discover subdomains, IP addresses, and other DNS records associated with a target domain. The tool is designed to be fast, efficient, and easy to use. This tool places emphasis on high-performance subdomain bruteforcing with advanced functionality for rapid enumeration and rate limiting mitigation.
 
 I originally started working on this project to learn Rust, improve on network programming, and gain a deeper understanding of DNS. This software includes its own stub resolver built from scratch, it is not a fully-featured DNS implementation and only supports the functionality required of it. I am still learning/improving my Rust skills, if you're experienced in Rust and think something could be improved, be more idomatic, or any other suggestions, feel free to let me know or submit a pull request!
 
@@ -138,7 +138,7 @@ docker run --rm -it ghcr.io/alexogden/reccedns:lists -m s -t github.com -w /opt/
 
 - `-Q` `--quiet` : Don't print any results to the terminal. Can be useful for targets with large amount of results that you are outputing to JSON.
 
-- `-T` `--threads` : Number of threads to use for subdomain enumeration. Defaults to logical cores - 1.
+- `-T` `--threads` : Number of threads to use for subdomain enumeration. Defaults to (logical cores - 1), however if cores is greater than 6 it will default to 6.
 
 ## Example Usage
 

--- a/src/dns/error.rs
+++ b/src/dns/error.rs
@@ -17,6 +17,6 @@ pub enum DnsError {
     ProtocolData(String),
     #[error("Internal Error: {0}")]
     Internal(String),
-    #[error("Connection Timeout")]
+    #[error("Resolver Timeout")]
     Timeout,
 }

--- a/src/io/cli.rs
+++ b/src/io/cli.rs
@@ -184,7 +184,6 @@ pub fn setup_progress_bar(total: u64) -> ProgressBar {
         .tick_chars(PROGRESS_TICK_CHARS);
     pb.set_style(style);
     pb.set_prefix(format!("[{}/{}]", 0, total));
-    pb.set_message("Enumerating...");
     pb.enable_steady_tick(Duration::from_millis(100));
     pb
 }
@@ -202,8 +201,31 @@ pub fn setup_basic_spinner() -> ProgressBar {
     spinner
 }
 
-/// Updates the progress bar based on the current index and total
-pub fn update_progress_bar(pb: &ProgressBar, index: usize, total: u64) {
-    pb.set_prefix(format!("[{}/{}]", index + 1, total));
+pub fn update_progress_bar(
+    pb: &ProgressBar,
+    index: usize,
+    total: u64,
+    failed_count: Option<usize>,
+    delay: Option<&Delay>,
+) {
+    // Set message based on delay
+    if let Some(d) = delay {
+        let delay_str = format!("{}ms", d.get_delay());
+        pb.set_message(format!("[Delay: {delay_str}]"));
+    } else {
+        // Clear message if no delay is provided
+        pb.set_message("");
+    }
+
+    // Set prefix with failed count
+    let failed_count = failed_count.unwrap_or(0);
+    let failed_str = if failed_count > 0 {
+        format!("[{}]", failed_count.to_string().red())
+    } else {
+        String::new()
+    };
+    pb.set_prefix(format!("[{}/{}] {}", index + 1, total, failed_str));
+
+    // Increment progress bar
     pb.inc(1);
 }

--- a/src/io/logger.rs
+++ b/src/io/logger.rs
@@ -28,16 +28,32 @@ impl std::fmt::Display for Status {
     }
 }
 
-pub fn status(status: &Status, message: &impl Display, newline: bool) {
-    let clear_line = "\r\x1b[2K";
-    let prefix = format!("{clear_line}[{status}] ");
-    let newline_str = if newline { "\n" } else { "" };
-    let formatted_message = format!("{newline_str}{prefix}{message}");
+pub fn status(status: &Status, message: &impl Display, add_newline: bool) {
+    let prefix = format!("[{status}] ");
+    let formatted_message = format!("{prefix}{message}");
 
+    // Determine the output stream and print method
     match status {
-        Status::Error => eprintln!("{formatted_message}"),
-        Status::Question => print!("{formatted_message}"),
-        _ => println!("{formatted_message}"),
+        Status::Error => {
+            if add_newline {
+                eprintln!("{formatted_message}");
+            } else {
+                eprint!("{formatted_message}");
+                let _ = std::io::stderr().flush();
+            }
+        }
+        Status::Question => {
+            print!("{formatted_message}");
+            let _ = std::io::stdout().flush();
+        }
+        _ => {
+            if add_newline {
+                println!("{formatted_message}");
+            } else {
+                print!("{formatted_message}");
+                let _ = std::io::stdout().flush();
+            }
+        }
     }
 }
 
@@ -60,91 +76,51 @@ pub fn clear_line() {
 }
 
 #[macro_export]
-macro_rules! log_info {
-    ($message:expr) => {
-        $crate::io::logger::status(
-            &$crate::io::logger::Status::Info,
-            &$message.to_string(),
-            false,
-        );
+macro_rules! _log_internal {
+    ($status:expr, $message:expr, $newline:expr) => {
+        $crate::io::logger::status(&$status, &$message, $newline);
     };
-    ($message:expr, $newline:expr) => {
-        $crate::io::logger::status(
-            &$crate::io::logger::Status::Info,
-            &$message.to_string(),
-            $newline,
-        );
+    ($status:expr, $message:expr) => {
+        let newline = !matches!($status, $crate::io::logger::Status::Question);
+        $crate::io::logger::status(&$status, &$message, newline);
+    };
+}
+
+#[macro_export]
+macro_rules! log_info {
+    ($($arg:tt)*) => {
+        $crate::_log_internal!($crate::io::logger::Status::Info, $($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! log_question {
+    // Question defaults to no newline
     ($message:expr) => {
-        $crate::io::logger::status(
-            &$crate::io::logger::Status::Question,
-            &$message.to_string(),
-            false,
-        );
+        $crate::_log_internal!($crate::io::logger::Status::Question, $message, false);
     };
     ($message:expr, $newline:expr) => {
-        $crate::io::logger::status(
-            &$crate::io::logger::Status::Question,
-            &$message.to_string(),
-            $newline,
-        );
+        $crate::_log_internal!($crate::io::logger::Status::Question, $message, $newline);
     };
 }
 
 #[macro_export]
 macro_rules! log_success {
-    ($message:expr) => {
-        $crate::io::logger::status(
-            &$crate::io::logger::Status::Success,
-            &$message.to_string(),
-            false,
-        );
-    };
-    ($message:expr, $newline:expr) => {
-        $crate::io::logger::status(
-            &$crate::io::logger::Status::Success,
-            &$message.to_string(),
-            $newline,
-        );
+    ($($arg:tt)*) => {
+        $crate::_log_internal!($crate::io::logger::Status::Success, $($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! log_warn {
-    ($message:expr) => {
-        $crate::io::logger::status(
-            &$crate::io::logger::Status::Warning,
-            &$message.to_string(),
-            false,
-        );
-    };
-    ($message:expr, $newline:expr) => {
-        $crate::io::logger::status(
-            &$crate::io::logger::Status::Warning,
-            &$message.to_string(),
-            $newline,
-        );
+    ($($arg:tt)*) => {
+        $crate::_log_internal!($crate::io::logger::Status::Warning, $($arg)*);
     };
 }
 
 #[macro_export]
 macro_rules! log_error {
-    ($message:expr) => {
-        $crate::io::logger::status(
-            &$crate::io::logger::Status::Error,
-            &$message.to_string(),
-            false,
-        );
-    };
-    ($message:expr, $newline:expr) => {
-        $crate::io::logger::status(
-            &$crate::io::logger::Status::Error,
-            &$message.to_string(),
-            $newline,
-        );
+    ($($arg:tt)*) => {
+        $crate::_log_internal!($crate::io::logger::Status::Error, $($arg)*);
     };
 }

--- a/src/io/logger.rs
+++ b/src/io/logger.rs
@@ -28,32 +28,16 @@ impl std::fmt::Display for Status {
     }
 }
 
-pub fn status(status: &Status, message: &impl Display, add_newline: bool) {
-    let prefix = format!("[{status}] ");
-    let formatted_message = format!("{prefix}{message}");
+pub fn status(status: &Status, message: &impl Display, newline: bool) {
+    let clear_line = "\r\x1b[2K";
+    let prefix = format!("{clear_line}[{status}] ");
+    let newline_str = if newline { "\n" } else { "" };
+    let formatted_message = format!("{newline_str}{prefix}{message}");
 
-    // Determine the output stream and print method
     match status {
-        Status::Error => {
-            if add_newline {
-                eprintln!("{formatted_message}");
-            } else {
-                eprint!("{formatted_message}");
-                let _ = std::io::stderr().flush();
-            }
-        }
-        Status::Question => {
-            print!("{formatted_message}");
-            let _ = std::io::stdout().flush();
-        }
-        _ => {
-            if add_newline {
-                println!("{formatted_message}");
-            } else {
-                print!("{formatted_message}");
-                let _ = std::io::stdout().flush();
-            }
-        }
+        Status::Error => eprintln!("{formatted_message}"),
+        Status::Question => print!("{formatted_message}"),
+        _ => println!("{formatted_message}"),
     }
 }
 
@@ -76,51 +60,91 @@ pub fn clear_line() {
 }
 
 #[macro_export]
-macro_rules! _log_internal {
-    ($status:expr, $message:expr, $newline:expr) => {
-        $crate::io::logger::status(&$status, &$message, $newline);
-    };
-    ($status:expr, $message:expr) => {
-        let newline = !matches!($status, $crate::io::logger::Status::Question);
-        $crate::io::logger::status(&$status, &$message, newline);
-    };
-}
-
-#[macro_export]
 macro_rules! log_info {
-    ($($arg:tt)*) => {
-        $crate::_log_internal!($crate::io::logger::Status::Info, $($arg)*);
+    ($message:expr) => {
+        $crate::io::logger::status(
+            &$crate::io::logger::Status::Info,
+            &$message.to_string(),
+            false,
+        );
+    };
+    ($message:expr, $newline:expr) => {
+        $crate::io::logger::status(
+            &$crate::io::logger::Status::Info,
+            &$message.to_string(),
+            $newline,
+        );
     };
 }
 
 #[macro_export]
 macro_rules! log_question {
-    // Question defaults to no newline
     ($message:expr) => {
-        $crate::_log_internal!($crate::io::logger::Status::Question, $message, false);
+        $crate::io::logger::status(
+            &$crate::io::logger::Status::Question,
+            &$message.to_string(),
+            false,
+        );
     };
     ($message:expr, $newline:expr) => {
-        $crate::_log_internal!($crate::io::logger::Status::Question, $message, $newline);
+        $crate::io::logger::status(
+            &$crate::io::logger::Status::Question,
+            &$message.to_string(),
+            $newline,
+        );
     };
 }
 
 #[macro_export]
 macro_rules! log_success {
-    ($($arg:tt)*) => {
-        $crate::_log_internal!($crate::io::logger::Status::Success, $($arg)*);
+    ($message:expr) => {
+        $crate::io::logger::status(
+            &$crate::io::logger::Status::Success,
+            &$message.to_string(),
+            false,
+        );
+    };
+    ($message:expr, $newline:expr) => {
+        $crate::io::logger::status(
+            &$crate::io::logger::Status::Success,
+            &$message.to_string(),
+            $newline,
+        );
     };
 }
 
 #[macro_export]
 macro_rules! log_warn {
-    ($($arg:tt)*) => {
-        $crate::_log_internal!($crate::io::logger::Status::Warning, $($arg)*);
+    ($message:expr) => {
+        $crate::io::logger::status(
+            &$crate::io::logger::Status::Warning,
+            &$message.to_string(),
+            false,
+        );
+    };
+    ($message:expr, $newline:expr) => {
+        $crate::io::logger::status(
+            &$crate::io::logger::Status::Warning,
+            &$message.to_string(),
+            $newline,
+        );
     };
 }
 
 #[macro_export]
 macro_rules! log_error {
-    ($($arg:tt)*) => {
-        $crate::_log_internal!($crate::io::logger::Status::Error, $($arg)*);
+    ($message:expr) => {
+        $crate::io::logger::status(
+            &$crate::io::logger::Status::Error,
+            &$message.to_string(),
+            false,
+        );
+    };
+    ($message:expr, $newline:expr) => {
+        $crate::io::logger::status(
+            &$crate::io::logger::Status::Error,
+            &$message.to_string(),
+            $newline,
+        );
     };
 }

--- a/src/modes/basic_enumerator.rs
+++ b/src/modes/basic_enumerator.rs
@@ -37,10 +37,11 @@ pub async fn enumerate_records(cmd_args: &CommandArgs, dns_resolvers: &[&str]) -
         .as_ref()
         .map(|_| DnsEnumerationOutput::new(cmd_args.target.clone()));
 
-    let query_types = match cmd_args.query_types.as_slice() {
-        [] | [QueryType::ANY] => DEFAULT_QUERY_TYPES.to_vec(),
-        _ => cmd_args.query_types.clone(),
+    let query_types: &[QueryType] = match cmd_args.query_types.as_slice() {
+        [] | [QueryType::ANY] => DEFAULT_QUERY_TYPES,
+        qt => qt,
     };
+
     let resolver = dns_resolvers[0];
     let domain = &cmd_args.target;
     let mut seen_cnames = HashSet::new();
@@ -56,7 +57,7 @@ pub async fn enumerate_records(cmd_args: &CommandArgs, dns_resolvers: &[&str]) -
             .resolve(
                 resolver,
                 domain,
-                &query_type,
+                query_type,
                 &cmd_args.transport_protocol,
                 !&cmd_args.no_recursion,
             )

--- a/src/modes/basic_enumerator.rs
+++ b/src/modes/basic_enumerator.rs
@@ -37,10 +37,9 @@ pub async fn enumerate_records(cmd_args: &CommandArgs, dns_resolvers: &[&str]) -
         .as_ref()
         .map(|_| DnsEnumerationOutput::new(cmd_args.target.clone()));
 
-    let query_types = if cmd_args.query_types.is_empty() {
-        DEFAULT_QUERY_TYPES.to_vec()
-    } else {
-        cmd_args.query_types.clone()
+    let query_types = match cmd_args.query_types.as_slice() {
+        [] | [QueryType::ANY] => DEFAULT_QUERY_TYPES.to_vec(),
+        _ => cmd_args.query_types.clone(),
     };
     let resolver = dns_resolvers[0];
     let domain = &cmd_args.target;

--- a/src/modes/cert_search.rs
+++ b/src/modes/cert_search.rs
@@ -89,11 +89,11 @@ pub async fn search_certificates(cmd_args: &CommandArgs) -> Result<()> {
             }
             Err(error) => {
                 spinner.finish_and_clear();
+                log_error!(format!(
+                    "Attempt {}/{} failed: {}. Retrying...",
+                    attempt, max_retries, error
+                ));
                 if attempt < max_retries && matches!(error, SearchError::NonSuccessStatus(_)) {
-                    log_error!(format!(
-                        "Attempt {}/{} failed: {}. Retrying...",
-                        attempt, max_retries, error
-                    ));
                     tokio::time::sleep(tokio::time::Duration::from_secs(attempt + 1)).await;
                 } else {
                     log_error!(format!(

--- a/src/modes/reverse_ip.rs
+++ b/src/modes/reverse_ip.rs
@@ -70,7 +70,7 @@ pub async fn reverse_ip(cmd_args: &CommandArgs, dns_resolver_list: &[&str]) -> R
             .await;
         query_timer.stop();
 
-        cli::update_progress_bar(&progress_bar, index, total_ips);
+        cli::update_progress_bar(&progress_bar, index, total_ips, None, None);
 
         match query_result {
             Ok(response) => {

--- a/src/modes/subdomain_enumerator.rs
+++ b/src/modes/subdomain_enumerator.rs
@@ -15,6 +15,7 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
+use tokio::time;
 
 use crate::{
     dns::{
@@ -338,7 +339,7 @@ async fn process_failed_subdomains(
         let mut results = HashSet::new();
 
         for query_type in &cmd_args.query_types {
-            thread::sleep(Duration::from_millis(adaptive_delay.get_delay()));
+            time::sleep(Duration::from_millis(adaptive_delay.get_delay())).await;
 
             match pool
                 .resolve(

--- a/src/modes/subdomain_enumerator.rs
+++ b/src/modes/subdomain_enumerator.rs
@@ -94,9 +94,17 @@ pub async fn enumerate_subdomains(
 
     let subdomain_list = read_wordlist(cmd_args.wordlist.as_ref())?;
 
-    let num_threads = cmd_args
-        .threads
-        .map_or_else(|| max(num_cpus::get() - 1, 1), |threads| threads);
+    let num_threads = cmd_args.threads.map_or_else(
+        || {
+            let cpus = num_cpus::get();
+            if cpus > 6 {
+                6
+            } else {
+                max(cpus - 1, 1)
+            }
+        },
+        |threads| threads,
+    );
 
     log_info!(format!(
         "Starting subdomain enumeration with {} threads",

--- a/src/modes/subdomain_enumerator.rs
+++ b/src/modes/subdomain_enumerator.rs
@@ -70,12 +70,20 @@ pub async fn enumerate_subdomains(
         return Ok(());
     }
 
-    let query_types =
-        if cmd_args.query_types.is_empty() || cmd_args.query_types.contains(&QueryType::ANY) {
-            DEFAULT_QUERY_TYPES.to_vec()
-        } else {
-            cmd_args.query_types.clone()
-        };
+    let query_types: &[QueryType] = match cmd_args.query_types.as_slice() {
+        [] | [QueryType::ANY] => DEFAULT_QUERY_TYPES,
+        qt => qt,
+    };
+
+    log_info!(format!(
+        "Using query types: {}",
+        query_types
+            .iter()
+            .map(|t| format!("{t:?}"))
+            .collect::<Vec<String>>()
+            .join(", ")
+            .bold()
+    ));
 
     // Prepare results output if JSON output is enabled.
     let mut results_output = if cmd_args.json.is_some() {
@@ -120,7 +128,7 @@ pub async fn enumerate_subdomains(
             connection_pool: pool.clone(),
             tx: tx.clone(),
             subdomains: chunk,
-            query_types: query_types.clone(),
+            query_types: query_types.to_vec(),
             target: cmd_args.target.clone(),
             transport: cmd_args.transport_protocol.clone(),
             dns_resolvers: dns_resolver_list

--- a/src/modes/tld_expander.rs
+++ b/src/modes/tld_expander.rs
@@ -1,7 +1,13 @@
 use anyhow::Result;
 use colored::Colorize;
 use std::fmt::Write as _;
-use std::{collections::HashSet, sync::atomic::Ordering, thread, time::Duration};
+use std::{
+    cmp::max,
+    collections::HashSet,
+    sync::{atomic::Ordering, mpsc},
+    thread,
+    time::{Duration, Instant},
+};
 
 use crate::dns::async_resolver_pool::AsyncResolverPool;
 use crate::{
@@ -9,7 +15,7 @@ use crate::{
         error::DnsError,
         format::create_query_response_string,
         protocol::{QueryType, ResourceRecord},
-        resolver_selector::{self, ResolverSelector},
+        resolver_selector::{self},
     },
     io::{
         cli::{self, CommandArgs},
@@ -18,146 +24,237 @@ use crate::{
         logger, wordlist,
     },
     log_error, log_info, log_success, log_warn,
-    timing::stats::QueryTimer,
+    network::types::TransportProtocol,
+    timing::delay,
 };
 
 const IANA_TLD_URL: &str = "https://data.iana.org/TLD/tlds-alpha-by-domain.txt";
 const DEFAULT_QUERY_TYPES: &[QueryType] = &[QueryType::A, QueryType::AAAA];
 
+type TldResult = Result<(String, String, HashSet<ResourceRecord>), (String, String, DnsError)>;
+type TldResultSender = mpsc::Sender<TldResult>;
+
+// Parameters for the worker threads.
+#[derive(Clone)]
+struct WorkerParams {
+    connection_pool: AsyncResolverPool,
+    tx: TldResultSender,
+    tlds: Vec<String>,
+    query_types: Vec<QueryType>,
+    target_base_domain: String,
+    transport: TransportProtocol,
+    dns_resolvers: Vec<String>,
+    use_random: bool,
+    delay: Option<delay::Delay>,
+    no_recursion: bool,
+}
+
+#[allow(clippy::too_many_lines)]
 pub async fn expand_tlds(cmd_args: &CommandArgs, dns_resolver_list: &[&str]) -> Result<()> {
     let interrupted = interrupt::initialize_interrupt_handler()?;
-    let tld_list = get_tld_list(cmd_args).await?;
+    let tld_list_vec = get_tld_list(cmd_args).await?;
+    let tld_set: HashSet<String> = tld_list_vec.iter().cloned().collect(); // Keep set for strip_tld
 
-    let mut resolver_selector = resolver_selector::get_selector(
-        cmd_args.use_random,
-        dns_resolver_list
-            .iter()
-            .map(std::string::ToString::to_string)
-            .collect(),
-    );
-    let mut query_timer = QueryTimer::new(!cmd_args.no_query_stats);
+    let target_fqdn = &cmd_args.target;
+    let target_base_domain = strip_tld(target_fqdn, &tld_set);
+
     let mut results_output = cmd_args
         .json
         .as_ref()
         .map(|_| DnsEnumerationOutput::new(cmd_args.target.clone()));
 
-    let target_fqdn = &cmd_args.target;
-    let target_base_domain = strip_tld(target_fqdn, &tld_list);
-
-    let progress_bar = cli::setup_progress_bar(tld_list.len() as u64);
-    progress_bar.set_message("Performing TLD expansion search...");
+    let num_threads = cmd_args
+        .threads
+        .map_or_else(|| max(num_cpus::get() - 1, 1), |threads| threads);
 
     log_info!(format!(
-        "Performing TLD Expansion for {}",
-        target_base_domain.cyan().italic()
+        "Starting TLD expansion for {} with {} threads",
+        target_base_domain.cyan().italic(),
+        num_threads.to_string().bold()
     ));
 
-    for (idx, tld) in tld_list.iter().enumerate() {
-        if interrupted.load(Ordering::SeqCst) {
-            logger::clear_line();
-            log_warn!("Interrupted by user".to_string(), true);
-            break;
-        }
+    // Split TLD list into chunks for each thread.
+    let chunk_size = tld_list_vec.len().div_ceil(num_threads);
+    let tld_chunks: Vec<Vec<String>> = tld_list_vec
+        .chunks(chunk_size)
+        .map(<[std::string::String]>::to_vec)
+        .collect();
 
-        cli::update_progress_bar(
-            &progress_bar,
-            idx,
-            tld_list.len() as u64,
-            None,
-            cmd_args.delay.as_ref(),
-        );
+    let progress_bar = cli::setup_progress_bar(tld_list_vec.len() as u64);
+    progress_bar.set_message("Performing TLD expansion search...");
 
-        let query_fqdn = format!("{target_base_domain}.{tld}");
-        process_domain(
-            &query_fqdn,
-            &mut *resolver_selector,
-            &mut query_timer,
-            &mut results_output,
-            cmd_args,
-        )
-        .await?;
+    let start_time = Instant::now();
 
-        if let Some(delay_ms) = &cmd_args.delay {
-            thread::sleep(Duration::from_millis(delay_ms.get_delay()));
-        }
-    }
+    let (tx, rx) = mpsc::channel();
+    let pool = AsyncResolverPool::new(Some(2 * num_threads)).await?;
 
-    progress_bar.finish_and_clear();
-
-    if let Some(avg) = query_timer.average() {
-        if !cmd_args.no_query_stats {
-            log_info!(format!(
-                "Average query time: {} ms",
-                avg.to_string().bold().bright_yellow()
-            ));
-        }
-    }
-
-    if let (Some(output), Some(file)) = (results_output, &cmd_args.json) {
-        output.write_to_file(file)?;
-    }
-    Ok(())
-}
-
-async fn process_domain(
-    domain_name: &str,
-    resolver_selector: &mut dyn ResolverSelector,
-    query_timer: &mut QueryTimer,
-    results_output: &mut Option<DnsEnumerationOutput>,
-    cmd_args: &CommandArgs,
-) -> Result<()> {
-    let resolver = resolver_selector.select()?;
     let query_types = if cmd_args.query_types.is_empty() {
         DEFAULT_QUERY_TYPES.to_vec()
     } else {
         cmd_args.query_types.clone()
     };
-    let mut all_query_results = HashSet::<ResourceRecord>::new();
-    let mut query_success = false;
 
-    let resolver_pool = AsyncResolverPool::new(Some(2)).await?;
+    // Spawn worker threads.
+    for chunk in tld_chunks {
+        let worker_params = WorkerParams {
+            connection_pool: pool.clone(),
+            tx: tx.clone(),
+            tlds: chunk,
+            query_types: query_types.clone(),
+            target_base_domain: target_base_domain.clone(),
+            transport: cmd_args.transport_protocol.clone(),
+            dns_resolvers: dns_resolver_list
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
+            use_random: cmd_args.use_random,
+            delay: cmd_args.delay.clone(),
+            no_recursion: cmd_args.no_recursion,
+        };
 
-    for query_type in query_types {
-        query_timer.start();
-        let query_result = resolver_pool
-            .resolve(
-                resolver,
-                domain_name,
-                &query_type,
-                &cmd_args.transport_protocol,
-                !cmd_args.no_recursion,
-            )
-            .await;
-        query_timer.stop();
+        thread::spawn(move || {
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(process_tld_chunk(worker_params));
+        });
+    }
+    drop(tx); // Close original sender.
 
-        // If the query succeeds, add all answer records.
-        if let Ok(response) = query_result {
-            all_query_results.extend(response.answers);
-            query_success = true;
-        } else if let Err(ref error) = query_result {
-            if !error.to_string().contains("(os error 4)") {
-                print_query_error(cmd_args, domain_name, resolver, error);
+    // Process results from the receiver.
+    let mut found_count = 0;
+    let mut error_count = 0;
+    for (i, received) in rx.into_iter().enumerate() {
+        if interrupted.load(Ordering::SeqCst) {
+            logger::clear_line();
+            log_warn!("Interrupted by user".to_string(), true);
+            pool.shutdown();
+            break;
+        }
+        match received {
+            Ok((fqdn, resolver, results)) => {
+                let response_str = create_query_response_string(&results);
+                found_count += 1;
+                print_query_result(cmd_args, &fqdn, &resolver, &response_str);
+
+                if let Some(output) = &mut results_output {
+                    results.iter().for_each(|r| output.add_result(r.clone()));
+                }
+            }
+            Err((fqdn, resolver, error)) => {
+                if !matches!(
+                    error,
+                    DnsError::NoRecordsFound | DnsError::NonExistentDomain
+                ) {
+                    error_count += 1;
+                }
+                print_query_error(cmd_args, &fqdn, &resolver, &error);
             }
         }
+
+        cli::update_progress_bar(
+            &progress_bar,
+            ((i as u64) + 1).try_into().unwrap(),
+            tld_list_vec.len() as u64,
+            Some(error_count), // Show error count instead of failed subdomains
+            cmd_args.delay.as_ref(),
+        );
     }
 
-    if !all_query_results.is_empty() {
-        let response_output = create_query_response_string(&all_query_results);
-        print_query_result(cmd_args, domain_name, resolver, &response_output);
+    progress_bar.finish_and_clear();
 
-        if let Some(output) = results_output {
-            for record in all_query_results {
-                output.add_result(record);
-            }
-        }
+    let elapsed_time = start_time.elapsed();
+    log_info!(
+        format!(
+            "Done! Found {} valid TLDs for {} in {:.2?}",
+            found_count.to_string().bold(),
+            target_base_domain.cyan().italic(),
+            elapsed_time
+        ),
+        true
+    );
+
+    if let (Some(output), Some(file)) = (results_output, &cmd_args.json) {
+        output.write_to_file(file)?;
     }
 
-    // Report query result to adaptive delay mechanism if it's being used
-    if let Some(delay) = &cmd_args.delay {
-        delay.report_query_result(query_success);
-    }
+    pool.shutdown();
 
     Ok(())
+}
+
+async fn process_tld_chunk(params: WorkerParams) {
+    let pool = params.connection_pool;
+    let mut resolver_selector =
+        resolver_selector::get_selector(params.use_random, params.dns_resolvers.clone());
+
+    for tld in params.tlds {
+        let resolver = resolver_selector
+            .select()
+            .unwrap_or(resolver_selector::DEFAULT_RESOLVER)
+            .to_string();
+        let query_fqdn = format!("{}.{}", params.target_base_domain, tld);
+        let mut all_query_results = HashSet::<ResourceRecord>::new();
+        let mut first_error: Option<DnsError> = None;
+        let mut query_success = false;
+
+        for query_type in &params.query_types {
+            let query_result = pool
+                .resolve(
+                    &resolver,
+                    &query_fqdn,
+                    query_type,
+                    &params.transport,
+                    !params.no_recursion,
+                )
+                .await;
+
+            // If the query succeeds, add all answer records.
+            if let Ok(response) = query_result {
+                all_query_results.extend(response.answers);
+                query_success = true;
+            } else if let Err(ref error) = query_result {
+                // If it's a network error, temporarily disable this resolver.
+                if let DnsError::Network(_) = error {
+                    let duration = Duration::from_secs(rand::random::<u64>() % 26 + 5); // 5-30 seconds
+                    resolver_selector.disable(&resolver, duration);
+                }
+                // Treat "no records" and "non-existent domain" as successful queries for delay logic.
+                if matches!(
+                    error,
+                    DnsError::NoRecordsFound | DnsError::NonExistentDomain
+                ) {
+                    query_success = true;
+                }
+
+                first_error.get_or_insert_with(|| query_result.err().unwrap());
+            }
+        }
+
+        // Report query result to adaptive delay mechanism if it's being used
+        if let Some(delay) = &params.delay {
+            delay.report_query_result(query_success);
+        }
+
+        // Send result back to main thread
+        let send_result = if !all_query_results.is_empty() {
+            params
+                .tx
+                .send(Ok((query_fqdn, resolver.to_string(), all_query_results)))
+        } else if let Some(err) = first_error {
+            params.tx.send(Err((query_fqdn, resolver.to_string(), err)))
+        } else {
+            Ok(())
+        };
+
+        if send_result.is_err() {
+            // Receiver has likely been dropped, main thread probably exited.
+            return;
+        }
+
+        if let Some(delay) = &params.delay {
+            thread::sleep(Duration::from_millis(delay.get_delay()));
+        }
+    }
 }
 
 fn strip_tld(domain: &str, tld_list: &HashSet<String>) -> String {
@@ -175,6 +272,7 @@ fn strip_tld(domain: &str, tld_list: &HashSet<String>) -> String {
             return normalized[..normalized.len() - suffix.len()].to_string();
         }
         if normalized_lower == candidate_lower {
+            // If the input domain *is* a TLD, return empty string
             return String::new();
         }
     }
@@ -182,17 +280,18 @@ fn strip_tld(domain: &str, tld_list: &HashSet<String>) -> String {
     normalized
 }
 
-async fn get_tld_list(cmd_args: &CommandArgs) -> Result<HashSet<String>> {
+async fn get_tld_list(cmd_args: &CommandArgs) -> Result<Vec<String>> {
     if let Some(wordlist_path) = &cmd_args.wordlist {
         let tld_list = wordlist::read_from_file(wordlist_path)?;
-        let tld_set: HashSet<String> = tld_list.into_iter().collect();
-        log_success!(format!("Using wordlist with {} TLDs", tld_set.len()));
-        Ok(tld_set)
+        log_success!(format!("Using wordlist with {} TLDs", tld_list.len()));
+        Ok(tld_list)
     } else {
         let iana_list = retrieve_iana_tld_list(cmd_args).await?;
-        let tld_set: HashSet<String> = iana_list.into_iter().collect();
-        log_success!(format!("Fetched IANA TLD list with {} TLDs", tld_set.len()));
-        Ok(tld_set)
+        log_success!(format!(
+            "Fetched IANA TLD list with {} TLDs",
+            iana_list.len()
+        ));
+        Ok(iana_list)
     }
 }
 
@@ -211,10 +310,13 @@ async fn retrieve_iana_tld_list(cmd_args: &CommandArgs) -> Result<Vec<String>> {
                         "Attempt {}/{} failed: {}. Retrying...",
                         attempt, max_attempts, e
                     ));
-                    thread::sleep(Duration::from_secs(2));
+                    tokio::time::sleep(Duration::from_secs(2)).await;
                     attempt += 1;
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    spinner.finish_and_clear();
+                    return Err(e);
+                }
             }
         }
     };
@@ -226,7 +328,7 @@ async fn fetch_and_filter_tld_list() -> Result<Vec<String>> {
     let response = reqwest::get(IANA_TLD_URL).await?.text().await?;
     let tld_list = response
         .lines()
-        .filter(|line| !line.starts_with('#'))
+        .filter(|line| !line.starts_with('#') && !line.trim().is_empty())
         .map(|s| s.trim().to_lowercase())
         .collect();
     Ok(tld_list)
@@ -302,7 +404,7 @@ mod tests {
         let tlds = create_tld_set(&["org"]);
         let domain = "org";
         let result = strip_tld(domain, &tlds);
-        assert_eq!(result, "");
+        assert_eq!(result, ""); // Expect empty string if input is just a TLD
     }
 
     #[test]
@@ -310,7 +412,7 @@ mod tests {
         let tlds = create_tld_set(&["com", "net"]);
         let domain = "example.org";
         let result = strip_tld(domain, &tlds);
-        assert_eq!(result, "example.org");
+        assert_eq!(result, "example.org"); // Expect original if no TLD matches
     }
 
     #[test]
@@ -327,5 +429,21 @@ mod tests {
         let domain = "example.com";
         let result = strip_tld(domain, &tlds);
         assert_eq!(result, "example");
+    }
+
+    #[test]
+    fn test_strip_tld_input_is_tld_itself() {
+        let tlds = create_tld_set(&["com", "net", "org"]);
+        let domain = "com";
+        let result = strip_tld(domain, &tlds);
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_strip_tld_input_is_longer_tld() {
+        let tlds = create_tld_set(&["uk", "co.uk"]);
+        let domain = "co.uk";
+        let result = strip_tld(domain, &tlds);
+        assert_eq!(result, "");
     }
 }

--- a/src/modes/tld_expander.rs
+++ b/src/modes/tld_expander.rs
@@ -59,7 +59,14 @@ pub async fn expand_tlds(cmd_args: &CommandArgs, dns_resolver_list: &[&str]) -> 
             break;
         }
 
-        cli::update_progress_bar(&progress_bar, idx, tld_list.len() as u64);
+        cli::update_progress_bar(
+            &progress_bar,
+            idx,
+            tld_list.len() as u64,
+            None,
+            cmd_args.delay.as_ref(),
+        );
+
         let query_fqdn = format!("{target_base_domain}.{tld}");
         process_domain(
             &query_fqdn,

--- a/src/modes/tld_expander.rs
+++ b/src/modes/tld_expander.rs
@@ -63,9 +63,17 @@ pub async fn expand_tlds(cmd_args: &CommandArgs, dns_resolver_list: &[&str]) -> 
         .as_ref()
         .map(|_| DnsEnumerationOutput::new(cmd_args.target.clone()));
 
-    let num_threads = cmd_args
-        .threads
-        .map_or_else(|| max(num_cpus::get() - 1, 1), |threads| threads);
+    let num_threads = cmd_args.threads.map_or_else(
+        || {
+            let cpus = num_cpus::get();
+            if cpus > 6 {
+                6
+            } else {
+                max(cpus - 1, 1)
+            }
+        },
+        |threads| threads,
+    );
 
     log_info!(format!(
         "Starting TLD expansion for {} with {} threads",

--- a/src/timing/delay.rs
+++ b/src/timing/delay.rs
@@ -11,7 +11,6 @@ pub enum Delay {
     Adaptive(Arc<AdaptiveDelayState>),
 }
 
-/// State tracking for adaptive delay adjustments
 #[derive(Debug)]
 pub struct AdaptiveDelayState {
     min_delay: u64,
@@ -40,7 +39,7 @@ impl AdaptiveDelayState {
         self.total_queries.fetch_add(1, Ordering::Relaxed);
 
         // Only adjust every 20 queries to avoid overreacting
-        if self.total_queries.load(Ordering::Relaxed) % 25 == 0 {
+        if self.total_queries.load(Ordering::Relaxed) % 20 == 0 {
             let current = self.current_delay.load(Ordering::Relaxed);
             let success_rate = self.get_success_rate();
 
@@ -66,7 +65,6 @@ impl AdaptiveDelayState {
             // For very small values, use a fixed increment
             current + 5
         } else {
-            // Normal 25% increase for larger values
             (current * 5) / 4
         };
 
@@ -80,7 +78,7 @@ impl AdaptiveDelayState {
         let total = self.total_queries.load(Ordering::Relaxed) as f64;
 
         if total == 0.0 {
-            return 1.0; // Default to optimistic
+            return 1.0;
         }
 
         success / total


### PR DESCRIPTION
This pull request introduces several updates to the project, including a version bump, improved documentation, enhanced user feedback in the CLI, and refactored DNS enumeration logic. Below are the key changes grouped by theme:

### Version and Dependency Updates
* Updated the project version from `0.11.0` to `0.12.0` in `Cargo.toml` to reflect new changes.
* Upgraded the `anyhow` dependency from `1.0.97` to `1.0.98` for compatibility and stability improvements.

### Documentation Enhancements
* Redesigned the `README.md` with a more visually appealing structure, including badges for build status, latest release, and commit activity. Added collapsible sections for installation, pre-built binaries, Docker images, and arguments. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L1-R14) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L35-R48) [[3]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L61-R256)
* Reorganized and reformatted the argument descriptions into a table for better readability.

### CLI Improvements
* Enhanced the progress bar to display dynamic delay information and a count of failed queries. This provides more detailed feedback during DNS enumeration.
* Renamed the "Connection Timeout" error to "Resolver Timeout" for clarity in `dns/error.rs`.

### Refactoring and Code Simplification
* Refactored DNS enumeration logic in `basic_enumerator.rs` by introducing helper functions like `process_and_format_record` and restructuring `check_dnssec` to reuse an existing resolver pool. This improves modularity and reduces redundant code. [[1]](diffhunk://#diff-739467d5bec7f0fe0f93bc3fa11a84df1d21d3c8488a9298024ae96fb9f0825aL40-R59) [[2]](diffhunk://#diff-739467d5bec7f0fe0f93bc3fa11a84df1d21d3c8488a9298024ae96fb9f0825aL103-R108) [[3]](diffhunk://#diff-739467d5bec7f0fe0f93bc3fa11a84df1d21d3c8488a9298024ae96fb9f0825aR133-R187)
* Adjusted how query types are handled, ensuring `DEFAULT_QUERY_TYPES` is used only when no specific query types are provided.

### Minor Workflow Update
* Renamed the "Run Tests" workflow to "Tests" in `.github/workflows/cargo_test.yml` for brevity.