### PR TITLE
v0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,18 +905,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,11 +170,11 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1149,15 +1149,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -124,9 +124,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -247,9 +247,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "futures-channel"
@@ -604,9 +604,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "ppv-lite86"
@@ -628,18 +628,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -773,18 +773,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4910321ebe4151be888e35fe062169554e74aad01beafed60410131420ceffbc"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -860,9 +860,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -1317,18 +1317,18 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1343,6 +1343,6 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "1966f8ac2c1f76987d69a74d0e0f929241c10e78136434e3be70ff7f58f64214"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "reccedns"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.100"
 clap = { version = "4.5.54", features = ["derive", "env"] }
-colored = "3.0.0"
+colored = "3.1.1"
 ctrlc = "3.5.1"
 dashmap = "6.1.0"
 indicatif = "0.18.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ regex = "1.12.2"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 strum_macros = "0.27.2"
-thiserror = "2.0.17"
+thiserror = "2.0.18"
 tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread", "io-util", "net", "sync", "time"] }
 hyper = { version = "1.8.1", default-features = false, features = ["client", "http1"] }
 hyper-util = { version = "0.1.19", default-features = false, features = ["client", "client-legacy", "http1"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reccedns"
 authors = ["Alex Ogden"]
-version = "0.17.1"
+version = "0.18.0"
 repository = "https://github.com/alexogden/reccedns"
 license = "GPL-3.0"
 edition = "2024"

--- a/docs/README.md
+++ b/docs/README.md
@@ -132,7 +132,7 @@ See the [releases](https://github.com/AlexOgden/RecceDNS/releases) page for the 
 |----------|---------------------|-------------|
 | `-m, --mode <MODE>` | `RECCEDNS_MODE` | **Operation mode**. Possible values:<br>• `b`: Basic Enumeration<br>• `s`: Subdomain Enumeration<br>• `r`: Reverse PTR IP<br>• `c`: Certificate Search<br>• `t`: TLD Expansion |
 | `-t, --target <TARGET>` | `RECCEDNS_TARGET` | **Target base domain or IP** (single, CIDR, or range).<br>Examples: `google.com`, `192.168.2.3`, `192.168.2.0/24`, `192.168.2.1-192.168.2.230`, `192.168.0.1,192.168.0.4` |
-| `-d, --dns-resolvers <DNS_RESOLVERS>` | `RECCEDNS_DNS_RESOLVERS` | **DNS resolver(s)** (IPv4, comma-separated, or file path).<br>Default: `1.1.1.1`.<br>You can provide a comma-separated list of IPv4 addresses, or a path to a file containing resolvers (one per line and/or CSV). Multiple resolvers can be selected randomly or sequentially (see `-r`). |
+| `-d, --dns-resolvers <DNS_RESOLVERS>` | `RECCEDNS_DNS_RESOLVERS` | **DNS resolver(s)** (IPv4, comma-separated, or file path).<br>Default: `1.1.1.1`.<br>You can provide a comma-separated list of IPv4 addresses, or a path to a file containing resolvers (one per line and/or CSV). Multiple resolvers can be selected randomly or sequentially (see `-r`).<br>**Custom port:** Append `:<port>` to specify a non-standard port (e.g., `1.1.1.1:5353`). Default port is `53`. |
 | `-p, --protocol <TRANSPORT_PROTOCOL>` | `RECCEDNS_PROTOCOL` | *(Optional)* **Transport protocol** for DNS queries.<br>Values: `UDP` (default), `TCP` |
 | `-w, --wordlist <WORDLIST>` | `RECCEDNS_WORDLIST` | **Path to subdomain wordlist**. Required for enumeration mode. |
 | `-v, --verbose` | `RECCEDNS_VERBOSE` | Print extra information. Default: `false` |

--- a/src/dns/async_resolver.rs
+++ b/src/dns/async_resolver.rs
@@ -31,7 +31,6 @@ const DEFAULT_POOL_SIZE: usize = 10; // Default number of UDP sockets in the poo
 const DEFAULT_TIMEOUT: Duration = Duration::from_millis(1500); // Default request timeout (UDP/TCP)
 const UDP_BUFFER_SIZE: usize = 512; // Standard DNS UDP buffer size for receiving
 const TCP_BUFFER_SIZE: usize = 65535; // Max DNS TCP message size
-const DNS_PORT: u16 = 53; // Standard DNS port
 
 #[derive(Clone)]
 pub struct AsyncResolver {
@@ -139,7 +138,7 @@ impl AsyncResolver {
 
     pub async fn resolve(
         &self,
-        dns_resolver: &Ipv4Addr,
+        dns_resolver: SocketAddr,
         domain: &str,
         query_type: &QueryType,
         protocol: &TransportProtocol,
@@ -168,7 +167,7 @@ impl AsyncResolver {
 
     async fn resolve_udp(
         &self,
-        dns_resolver: &Ipv4Addr,
+        dns_resolver: SocketAddr,
         mut query_packet: DnsPacket,
     ) -> Result<DnsPacket, DnsError> {
         if self.udp_sockets.is_empty() {
@@ -201,12 +200,10 @@ impl AsyncResolver {
             % self.udp_sockets.len();
         let udp_socket = &self.udp_sockets[udp_socket_index];
 
-        let target_sock_addr = SocketAddr::new((*dns_resolver).into(), DNS_PORT);
-
-        if let Err(e) = udp_socket.send_to(udp_request_data, target_sock_addr).await {
+        if let Err(e) = udp_socket.send_to(udp_request_data, dns_resolver).await {
             self.pending_queries.remove(&query_id);
             return Err(DnsError::Network(format!(
-                "UDP: Failed to send query to {target_sock_addr}: {e}"
+                "UDP: Failed to send query to {dns_resolver}: {e}"
             )));
         }
 
@@ -235,12 +232,10 @@ impl AsyncResolver {
 
     async fn resolve_tcp(
         &self,
-        dns_resolver: &Ipv4Addr,
+        dns_resolver: SocketAddr,
         mut query_packet: DnsPacket,
     ) -> Result<DnsPacket, DnsError> {
-        let target_sock_addr = SocketAddr::new((*dns_resolver).into(), DNS_PORT);
-
-        let tcp_connection_mutex = self.get_or_create_tcp_connection(target_sock_addr).await?;
+        let tcp_connection_mutex = self.get_or_create_tcp_connection(dns_resolver).await?;
         let mut tcp_connection_guard = tcp_connection_mutex.lock().await;
 
         let query_id = query_packet.header.id;
@@ -276,7 +271,7 @@ impl AsyncResolver {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
                     return Err(DnsError::Network(format!(
-                        "Failed to write request to {target_sock_addr}: {e}"
+                        "Failed to write request to {dns_resolver}: {e}"
                     )));
                 }
                 Err(_) => {
@@ -295,7 +290,7 @@ impl AsyncResolver {
                 Ok(Ok(_)) => {}
                 Ok(Err(e)) => {
                     return Err(DnsError::Network(format!(
-                        "Failed to read response length from {target_sock_addr}: {e}"
+                        "Failed to read response length from {dns_resolver}: {e}"
                     )));
                 }
                 Err(_) => {
@@ -327,7 +322,7 @@ impl AsyncResolver {
                 Ok(Ok(_)) => {}
                 Ok(Err(e)) => {
                     return Err(DnsError::Network(format!(
-                        "Failed to read response from {target_sock_addr}: {e}"
+                        "Failed to read response from {dns_resolver}: {e}"
                     )));
                 }
                 Err(_) => {
@@ -352,7 +347,7 @@ impl AsyncResolver {
         .await;
 
         if result.is_err() {
-            self.tcp_sockets.remove(&target_sock_addr);
+            self.tcp_sockets.remove(&dns_resolver);
         }
 
         result

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -3,3 +3,6 @@ pub mod error;
 pub mod format;
 pub mod protocol;
 pub mod resolver_selector;
+
+/// Default DNS port used when none is specified
+pub const DEFAULT_DNS_PORT: u16 = 53;

--- a/src/dns/resolver_selector.rs
+++ b/src/dns/resolver_selector.rs
@@ -1,19 +1,22 @@
 use dashmap::DashMap;
 use rand::Rng;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
+use super::DEFAULT_DNS_PORT;
+
 /// Default resolver used as fallback when all resolvers are disabled.
-pub const DEFAULT_RESOLVER: Ipv4Addr = Ipv4Addr::new(1, 1, 1, 1);
+pub const DEFAULT_RESOLVER: SocketAddr =
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(1, 1, 1, 1), DEFAULT_DNS_PORT));
 
 /// Cleanup disabled resolvers every N selections (must be power of 2 - 1 for fast modulo).
 const CLEANUP_INTERVAL_MASK: u64 = 0x3FF; // Every 1024 selects
 
 #[derive(Debug)]
 pub struct ResolverPool {
-    resolvers: Vec<Ipv4Addr>,
-    disabled: DashMap<Ipv4Addr, Instant>,
+    resolvers: Vec<SocketAddr>,
+    disabled: DashMap<SocketAddr, Instant>,
     index: AtomicUsize,
     select_count: AtomicU64,
     use_random: bool,
@@ -21,7 +24,7 @@ pub struct ResolverPool {
 
 impl ResolverPool {
     #[must_use]
-    pub fn new(resolvers: Vec<Ipv4Addr>, use_random: bool) -> Self {
+    pub fn new(resolvers: Vec<SocketAddr>, use_random: bool) -> Self {
         Self {
             resolvers,
             disabled: DashMap::new(),
@@ -36,7 +39,7 @@ impl ResolverPool {
     /// Returns `Some(resolver)` if one is available, or `None` if the pool is empty.
     /// If all resolvers are temporarily disabled, returns the first resolver as fallback.
     #[inline]
-    pub fn select(&self) -> Option<Ipv4Addr> {
+    pub fn select(&self) -> Option<SocketAddr> {
         if self.resolvers.is_empty() {
             return None;
         }
@@ -57,7 +60,7 @@ impl ResolverPool {
     }
 
     #[inline]
-    fn select_sequential(&self, len: usize) -> Option<Ipv4Addr> {
+    fn select_sequential(&self, len: usize) -> Option<SocketAddr> {
         // Try each resolver starting from current index
         for _ in 0..len {
             // Atomic increment with wrap-around
@@ -74,7 +77,7 @@ impl ResolverPool {
     }
 
     #[inline]
-    fn select_random(&self, len: usize) -> Option<Ipv4Addr> {
+    fn select_random(&self, len: usize) -> Option<SocketAddr> {
         let mut rng = rand::rng();
         let start = rng.random_range(0..len);
 
@@ -92,21 +95,21 @@ impl ResolverPool {
     }
 
     #[inline]
-    fn is_disabled(&self, resolver: Ipv4Addr) -> bool {
+    fn is_disabled(&self, resolver: SocketAddr) -> bool {
         self.disabled
             .get(&resolver)
             .is_some_and(|expiry| *expiry > Instant::now())
     }
 
     #[inline]
-    fn fallback(&self) -> Option<Ipv4Addr> {
+    fn fallback(&self) -> Option<SocketAddr> {
         self.resolvers.first().copied()
     }
 
     /// Temporarily disable a resolver for the specified duration.
     ///
     /// Will not disable if it would leave no resolvers available.
-    pub fn disable(&self, resolver: Ipv4Addr, duration: Duration) {
+    pub fn disable(&self, resolver: SocketAddr, duration: Duration) {
         // Don't disable the last available resolver
         let other_available = self
             .resolvers
@@ -161,12 +164,16 @@ impl Clone for ResolverPool {
 mod tests {
     use super::*;
 
-    fn test_resolvers() -> Vec<Ipv4Addr> {
+    fn test_resolvers() -> Vec<SocketAddr> {
         vec![
-            "1.1.1.1".parse().unwrap(),
-            "8.8.8.8".parse().unwrap(),
-            "9.9.9.9".parse().unwrap(),
+            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(1, 1, 1, 1), DEFAULT_DNS_PORT)),
+            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(8, 8, 8, 8), DEFAULT_DNS_PORT)),
+            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(9, 9, 9, 9), DEFAULT_DNS_PORT)),
         ]
+    }
+
+    fn resolver(ip: &str) -> SocketAddr {
+        SocketAddr::V4(SocketAddrV4::new(ip.parse().unwrap(), DEFAULT_DNS_PORT))
     }
 
     #[test]
@@ -188,10 +195,10 @@ mod tests {
     fn test_sequential_selection() {
         let pool = ResolverPool::new(test_resolvers(), false);
 
-        assert_eq!(pool.select(), Some("1.1.1.1".parse().unwrap()));
-        assert_eq!(pool.select(), Some("8.8.8.8".parse().unwrap()));
-        assert_eq!(pool.select(), Some("9.9.9.9".parse().unwrap()));
-        assert_eq!(pool.select(), Some("1.1.1.1".parse().unwrap())); // Cycles back
+        assert_eq!(pool.select(), Some(resolver("1.1.1.1")));
+        assert_eq!(pool.select(), Some(resolver("8.8.8.8")));
+        assert_eq!(pool.select(), Some(resolver("9.9.9.9")));
+        assert_eq!(pool.select(), Some(resolver("1.1.1.1"))); // Cycles back
     }
 
     #[test]
@@ -209,10 +216,10 @@ mod tests {
         let pool = ResolverPool::new(test_resolvers(), false);
 
         // Disable first resolver
-        pool.disable("1.1.1.1".parse().unwrap(), Duration::from_secs(10));
+        pool.disable(resolver("1.1.1.1"), Duration::from_secs(10));
 
         // Should skip to second resolver
-        assert_eq!(pool.select(), Some("8.8.8.8".parse().unwrap()));
+        assert_eq!(pool.select(), Some(resolver("8.8.8.8")));
         assert_eq!(pool.available_count(), 2);
     }
 
@@ -221,7 +228,7 @@ mod tests {
         let pool = ResolverPool::new(test_resolvers(), false);
 
         // Disable with very short duration
-        pool.disable("1.1.1.1".parse().unwrap(), Duration::from_millis(10));
+        pool.disable(resolver("1.1.1.1"), Duration::from_millis(10));
 
         // Wait for expiry
         std::thread::sleep(Duration::from_millis(20));
@@ -237,11 +244,11 @@ mod tests {
 
     #[test]
     fn test_cannot_disable_all() {
-        let resolvers = vec!["1.1.1.1".parse().unwrap(), "8.8.8.8".parse().unwrap()];
+        let resolvers = vec![resolver("1.1.1.1"), resolver("8.8.8.8")];
         let pool = ResolverPool::new(resolvers, false);
 
-        pool.disable("1.1.1.1".parse().unwrap(), Duration::from_secs(10));
-        pool.disable("8.8.8.8".parse().unwrap(), Duration::from_secs(10));
+        pool.disable(resolver("1.1.1.1"), Duration::from_secs(10));
+        pool.disable(resolver("8.8.8.8"), Duration::from_secs(10));
 
         // At least one should still be available (second disable should fail)
         assert!(pool.available_count() >= 1);
@@ -250,14 +257,14 @@ mod tests {
 
     #[test]
     fn test_fallback_when_all_disabled() {
-        let resolvers = vec!["1.1.1.1".parse().unwrap()];
+        let resolvers = vec![resolver("1.1.1.1")];
         let pool = ResolverPool::new(resolvers, false);
 
         // Can't disable the only resolver
-        pool.disable("1.1.1.1".parse().unwrap(), Duration::from_secs(10));
+        pool.disable(resolver("1.1.1.1"), Duration::from_secs(10));
 
         // Should still return the resolver as fallback
-        assert_eq!(pool.select(), Some("1.1.1.1".parse().unwrap()));
+        assert_eq!(pool.select(), Some(resolver("1.1.1.1")));
     }
 
     #[test]

--- a/src/dns/resolver_selector.rs
+++ b/src/dns/resolver_selector.rs
@@ -7,8 +7,10 @@ use std::time::{Duration, Instant};
 use super::DEFAULT_DNS_PORT;
 
 /// Default resolver used as fallback when all resolvers are disabled.
-pub const DEFAULT_RESOLVER: SocketAddr =
-    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(1, 1, 1, 1), DEFAULT_DNS_PORT));
+pub const DEFAULT_RESOLVER: SocketAddr = SocketAddr::V4(SocketAddrV4::new(
+    Ipv4Addr::new(1, 1, 1, 1),
+    DEFAULT_DNS_PORT,
+));
 
 /// Cleanup disabled resolvers every N selections (must be power of 2 - 1 for fast modulo).
 const CLEANUP_INTERVAL_MASK: u64 = 0x3FF; // Every 1024 selects
@@ -166,9 +168,18 @@ mod tests {
 
     fn test_resolvers() -> Vec<SocketAddr> {
         vec![
-            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(1, 1, 1, 1), DEFAULT_DNS_PORT)),
-            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(8, 8, 8, 8), DEFAULT_DNS_PORT)),
-            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(9, 9, 9, 9), DEFAULT_DNS_PORT)),
+            SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::new(1, 1, 1, 1),
+                DEFAULT_DNS_PORT,
+            )),
+            SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::new(8, 8, 8, 8),
+                DEFAULT_DNS_PORT,
+            )),
+            SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::new(9, 9, 9, 9),
+                DEFAULT_DNS_PORT,
+            )),
         ]
     }
 

--- a/src/io/validation.rs
+++ b/src/io/validation.rs
@@ -219,12 +219,13 @@ mod test {
 
     #[test]
     fn valid_ipv4_with_port() {
+        #[allow(clippy::ip_constant)]
         let valid_ips_with_port = [
             ("192.168.0.1:53", Ipv4Addr::new(192, 168, 0, 1), 53),
-            ("127.0.0.1:5353", Ipv4Addr::new(127, 0, 0, 1), 5353),
+            ("127.0.0.1:5353", Ipv4Addr::LOCALHOST, 5353),
             ("8.8.8.8:853", Ipv4Addr::new(8, 8, 8, 8), 853),
             ("1.1.1.1:1", Ipv4Addr::new(1, 1, 1, 1), 1),
-            ("0.0.0.0:65535", Ipv4Addr::new(0, 0, 0, 0), 65535),
+            ("0.0.0.0:65535", Ipv4Addr::UNSPECIFIED, 65535),
         ];
         for (input, expected_ip, expected_port) in valid_ips_with_port {
             let result = validate_ipv4(input);
@@ -232,14 +233,23 @@ mod test {
             assert_eq!(result.unwrap(), input);
 
             let parsed = parse_ipv4_with_port(input).unwrap();
-            assert_eq!(parsed, SocketAddr::V4(SocketAddrV4::new(expected_ip, expected_port)));
+            assert_eq!(
+                parsed,
+                SocketAddr::V4(SocketAddrV4::new(expected_ip, expected_port))
+            );
         }
     }
 
     #[test]
     fn ipv4_without_port_defaults_to_53() {
         let parsed = parse_ipv4_with_port("8.8.8.8").unwrap();
-        assert_eq!(parsed, SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(8, 8, 8, 8), DEFAULT_DNS_PORT)));
+        assert_eq!(
+            parsed,
+            SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::new(8, 8, 8, 8),
+                DEFAULT_DNS_PORT
+            ))
+        );
     }
 
     #[test]
@@ -542,7 +552,10 @@ mod test {
 
     #[test]
     fn dns_resolver_single_with_port() {
-        assert_eq!(validate_dns_resolvers("8.8.8.8:5353").unwrap(), "8.8.8.8:5353");
+        assert_eq!(
+            validate_dns_resolvers("8.8.8.8:5353").unwrap(),
+            "8.8.8.8:5353"
+        );
     }
 
     #[test]

--- a/src/io/validation.rs
+++ b/src/io/validation.rs
@@ -2,10 +2,11 @@ use anyhow::{Context, Result, anyhow, ensure};
 use regex::Regex;
 use std::{
     fs,
-    net::{IpAddr, Ipv4Addr},
+    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
     path::Path,
 };
 
+use crate::dns::DEFAULT_DNS_PORT;
 use crate::network::{check, types::TransportProtocol};
 use std::sync::LazyLock;
 
@@ -150,17 +151,41 @@ pub fn validate_dns_resolvers(servers: &str) -> Result<String> {
     Ok(server_list.join(","))
 }
 
-pub fn validate_ipv4(ip: &str) -> Result<String> {
-    ip.parse::<Ipv4Addr>()
-        .with_context(|| format!("Invalid IPv4 address: {ip}"))
-        .map(|_| ip.to_string())
+/// Parses an IPv4 address with an optional port.
+///
+/// Accepted formats:
+/// - `192.168.1.1` - IP only (defaults to port 53)
+/// - `192.168.1.1:5353` - IP with custom port
+pub fn parse_ipv4_with_port(input: &str) -> Result<SocketAddr> {
+    let input = input.trim();
+
+    if let Some((ip_part, port_part)) = input.rsplit_once(':') {
+        let ip = ip_part
+            .parse::<Ipv4Addr>()
+            .with_context(|| format!("Invalid IPv4 address: {ip_part}"))?;
+        let port = port_part
+            .parse::<u16>()
+            .with_context(|| format!("Invalid port number: {port_part}"))?;
+        Ok(SocketAddr::V4(SocketAddrV4::new(ip, port)))
+    } else {
+        let ip = input
+            .parse::<Ipv4Addr>()
+            .with_context(|| format!("Invalid IPv4 address: {input}"))?;
+        Ok(SocketAddr::V4(SocketAddrV4::new(ip, DEFAULT_DNS_PORT)))
+    }
+}
+
+/// Validates an IPv4 address with an optional port, returning the original string.
+pub fn validate_ipv4(input: &str) -> Result<String> {
+    parse_ipv4_with_port(input)?;
+    Ok(input.trim().to_string())
 }
 
 pub async fn filter_working_resolvers(
     no_dns_check: bool,
     transport_protocol: &TransportProtocol,
-    dns_resolvers: &[Ipv4Addr],
-) -> Vec<Ipv4Addr> {
+    dns_resolvers: &[SocketAddr],
+) -> Vec<SocketAddr> {
     if no_dns_check {
         return dns_resolvers.to_vec();
     }
@@ -193,9 +218,48 @@ mod test {
     }
 
     #[test]
+    fn valid_ipv4_with_port() {
+        let valid_ips_with_port = [
+            ("192.168.0.1:53", Ipv4Addr::new(192, 168, 0, 1), 53),
+            ("127.0.0.1:5353", Ipv4Addr::new(127, 0, 0, 1), 5353),
+            ("8.8.8.8:853", Ipv4Addr::new(8, 8, 8, 8), 853),
+            ("1.1.1.1:1", Ipv4Addr::new(1, 1, 1, 1), 1),
+            ("0.0.0.0:65535", Ipv4Addr::new(0, 0, 0, 0), 65535),
+        ];
+        for (input, expected_ip, expected_port) in valid_ips_with_port {
+            let result = validate_ipv4(input);
+            assert!(result.is_ok(), "Expected valid: {input}");
+            assert_eq!(result.unwrap(), input);
+
+            let parsed = parse_ipv4_with_port(input).unwrap();
+            assert_eq!(parsed, SocketAddr::V4(SocketAddrV4::new(expected_ip, expected_port)));
+        }
+    }
+
+    #[test]
+    fn ipv4_without_port_defaults_to_53() {
+        let parsed = parse_ipv4_with_port("8.8.8.8").unwrap();
+        assert_eq!(parsed, SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(8, 8, 8, 8), DEFAULT_DNS_PORT)));
+    }
+
+    #[test]
     fn invalid_ipv4() {
         assert!(validate_ipv4("256.0.0.1").is_err());
         assert!(validate_ipv4("127.0.0.1234").is_err());
+    }
+
+    #[test]
+    fn invalid_ipv4_with_port() {
+        // Invalid port (out of range)
+        assert!(validate_ipv4("192.168.1.1:65536").is_err());
+        // Invalid port (negative - parsed as invalid)
+        assert!(validate_ipv4("192.168.1.1:-1").is_err());
+        // Invalid port (not a number)
+        assert!(validate_ipv4("192.168.1.1:abc").is_err());
+        // Invalid IP with valid port
+        assert!(validate_ipv4("256.0.0.1:53").is_err());
+        // Empty port
+        assert!(validate_ipv4("192.168.1.1:").is_err());
     }
 
     #[test]
@@ -217,6 +281,19 @@ mod test {
     }
 
     #[test]
+    fn valid_dns_resolver_list_with_ports() {
+        assert_eq!(
+            validate_dns_resolvers("192.0.2.1:5353,8.8.8.8:853").unwrap(),
+            "192.0.2.1:5353,8.8.8.8:853"
+        );
+        // Mixed: some with ports, some without
+        assert_eq!(
+            validate_dns_resolvers("192.0.2.1,8.8.8.8:853").unwrap(),
+            "192.0.2.1,8.8.8.8:853"
+        );
+    }
+
+    #[test]
     fn invalid_dns_resolver_list() {
         // Test with invalid IP address
         assert!(validate_dns_resolvers("192.0.2.1,256.0.0.1").is_err());
@@ -226,6 +303,9 @@ mod test {
 
         // Test with invalid format
         assert!(validate_dns_resolvers("192.0.2.1,8.8.8.8,invalid").is_err());
+
+        // Test with invalid port
+        assert!(validate_dns_resolvers("192.0.2.1:65536").is_err());
     }
 
     #[test]
@@ -448,11 +528,21 @@ mod test {
             validate_dns_resolvers("8.8.8.8 , 1.1.1.1").unwrap(),
             "8.8.8.8,1.1.1.1"
         );
+        // With ports
+        assert_eq!(
+            validate_dns_resolvers("8.8.8.8:53 , 1.1.1.1:5353").unwrap(),
+            "8.8.8.8:53,1.1.1.1:5353"
+        );
     }
 
     #[test]
     fn dns_resolver_single() {
         assert_eq!(validate_dns_resolvers("8.8.8.8").unwrap(), "8.8.8.8");
+    }
+
+    #[test]
+    fn dns_resolver_single_with_port() {
+        assert_eq!(validate_dns_resolvers("8.8.8.8:5353").unwrap(), "8.8.8.8:5353");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,12 +4,12 @@ mod modes;
 mod network;
 mod timing;
 
-use std::{net::Ipv4Addr, path::Path};
+use std::{net::SocketAddr, path::Path};
 
 use anyhow::{Result, anyhow, ensure};
 use io::{
     cli::{self, OperationMode},
-    validation::filter_working_resolvers,
+    validation::{filter_working_resolvers, parse_ipv4_with_port},
 };
 use network::types::TransportProtocol;
 
@@ -63,7 +63,7 @@ fn load_resolvers_from_file(path: &str) -> Result<Vec<String>> {
     Ok(content.lines().flat_map(parse_resolvers).collect())
 }
 
-async fn initialize_dns_resolvers(cmd_args: &cli::CommandArgs) -> Result<Vec<Ipv4Addr>> {
+async fn initialize_dns_resolvers(cmd_args: &cli::CommandArgs) -> Result<Vec<SocketAddr>> {
     let no_dns_check =
         matches!(cmd_args.operation_mode, OperationMode::CertSearch) || cmd_args.no_dns_check;
 
@@ -79,16 +79,13 @@ async fn initialize_dns_resolvers(cmd_args: &cli::CommandArgs) -> Result<Vec<Ipv
         "No DNS resolvers provided! At least one resolver must be specified."
     );
 
-    let ipv4_resolvers: Vec<Ipv4Addr> = resolver_list
+    let resolvers: Vec<SocketAddr> = resolver_list
         .iter()
-        .map(|s| {
-            s.parse::<Ipv4Addr>()
-                .map_err(|_| anyhow!("Invalid IPv4 address: '{s}'"))
-        })
+        .map(|s| parse_ipv4_with_port(s))
         .collect::<Result<_, _>>()?;
 
     let working_resolvers =
-        filter_working_resolvers(no_dns_check, &cmd_args.transport_protocol, &ipv4_resolvers).await;
+        filter_working_resolvers(no_dns_check, &cmd_args.transport_protocol, &resolvers).await;
 
     ensure!(
         !working_resolvers.is_empty(),

--- a/src/modes/basic_enumerator.rs
+++ b/src/modes/basic_enumerator.rs
@@ -14,7 +14,7 @@ use crate::{
     timing::stats::QueryTimer,
 };
 use anyhow::Result;
-use std::{collections::HashSet, net::Ipv4Addr};
+use std::{collections::HashSet, net::SocketAddr};
 
 const DEFAULT_QUERY_TYPES: &[QueryType] = &[
     QueryType::A,
@@ -26,7 +26,7 @@ const DEFAULT_QUERY_TYPES: &[QueryType] = &[
     QueryType::SOA,
 ];
 
-pub async fn enumerate_records(cmd_args: &CommandArgs, dns_resolvers: &[Ipv4Addr]) -> Result<()> {
+pub async fn enumerate_records(cmd_args: &CommandArgs, dns_resolvers: &[SocketAddr]) -> Result<()> {
     println!(
         "Enumerating records for target domain: {}\n",
         cmd_args.target.bold().bright_blue()
@@ -48,13 +48,13 @@ pub async fn enumerate_records(cmd_args: &CommandArgs, dns_resolvers: &[Ipv4Addr
     let mut query_timer = QueryTimer::new(!cmd_args.no_query_stats);
     let resolver_pool = AsyncResolver::new(Some(1)).await?;
 
-    check_dnssec(&resolver_pool, &resolver, domain, cmd_args).await?;
+    check_dnssec(&resolver_pool, resolver, domain, cmd_args).await?;
 
     for query_type in query_types {
         query_timer.start();
         let query_result = resolver_pool
             .resolve(
-                &resolver,
+                resolver,
                 domain,
                 query_type,
                 &cmd_args.transport_protocol,
@@ -70,7 +70,7 @@ pub async fn enumerate_records(cmd_args: &CommandArgs, dns_resolvers: &[Ipv4Addr
                     &resolver_pool,
                     &mut seen_cnames,
                     &response.answers,
-                    &resolver,
+                    resolver,
                     &mut data_output,
                     cmd_args,
                 )
@@ -102,7 +102,7 @@ pub async fn enumerate_records(cmd_args: &CommandArgs, dns_resolvers: &[Ipv4Addr
 
 async fn check_dnssec(
     resolver_pool: &AsyncResolver,
-    resolver: &Ipv4Addr,
+    resolver: SocketAddr,
     domain: &str,
     cmd_args: &CommandArgs,
 ) -> Result<()> {
@@ -133,7 +133,7 @@ async fn process_response(
     resolver_pool: &AsyncResolver,
     seen_cnames: &mut HashSet<String>,
     response: &[ResourceRecord],
-    resolver: &Ipv4Addr,
+    resolver: SocketAddr,
     data_output: &mut Option<DnsEnumerationOutput>,
     cmd_args: &CommandArgs,
 ) -> Result<()> {
@@ -155,7 +155,7 @@ async fn process_and_format_record(
     resolver_pool: &AsyncResolver,
     seen_cnames: &mut HashSet<String>,
     record: &ResourceRecord,
-    resolver: &Ipv4Addr,
+    resolver: SocketAddr,
     data_output: &mut Option<DnsEnumerationOutput>,
     cmd_args: &CommandArgs,
 ) -> Result<()> {

--- a/src/modes/reverse_ip.rs
+++ b/src/modes/reverse_ip.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use colored::Colorize;
 use std::{
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     sync::atomic::Ordering,
     time::Duration,
     vec,
@@ -23,7 +23,7 @@ use crate::{
     timing::stats::QueryTimer,
 };
 
-pub async fn reverse_ip(cmd_args: &CommandArgs, dns_resolver_list: &[Ipv4Addr]) -> Result<()> {
+pub async fn reverse_ip(cmd_args: &CommandArgs, dns_resolver_list: &[SocketAddr]) -> Result<()> {
     let interrupted = interrupt::initialize_interrupt_handler()?;
 
     let target_ips = parse_ip(&cmd_args.target)?;
@@ -56,7 +56,7 @@ pub async fn reverse_ip(cmd_args: &CommandArgs, dns_resolver_list: &[Ipv4Addr]) 
         query_timer.start();
         let query_result = async_resolver
             .resolve(
-                &resolver,
+                resolver,
                 &ip.to_string(),
                 &QueryType::PTR,
                 &cmd_args.transport_protocol,

--- a/src/modes/shared_state.rs
+++ b/src/modes/shared_state.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 use std::{
-    net::Ipv4Addr,
+    net::SocketAddr,
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -39,7 +39,7 @@ pub struct LookupContext {
 }
 
 pub struct QueryFailure {
-    pub resolver: Ipv4Addr,
+    pub resolver: SocketAddr,
     pub error: DnsError,
 }
 
@@ -126,7 +126,7 @@ impl LookupContext {
         fqdn: &str,
         query_type: QueryType,
         first_query: &mut bool,
-    ) -> Result<(Ipv4Addr, DnsPacket), QueryFailure> {
+    ) -> Result<(SocketAddr, DnsPacket), QueryFailure> {
         let should_wait = !*first_query;
         if *first_query {
             *first_query = false;
@@ -141,7 +141,7 @@ impl LookupContext {
         &self,
         fqdn: &str,
         query_type: QueryType,
-    ) -> Result<(Ipv4Addr, DnsPacket), QueryFailure> {
+    ) -> Result<(SocketAddr, DnsPacket), QueryFailure> {
         // Lock-free resolver selection
         let resolver = self
             .resolver_pool
@@ -151,7 +151,7 @@ impl LookupContext {
         let result = self
             .pool
             .resolve(
-                &resolver,
+                resolver,
                 fqdn,
                 &query_type,
                 &self.transport,

--- a/src/modes/shared_state.rs
+++ b/src/modes/shared_state.rs
@@ -150,13 +150,7 @@ impl LookupContext {
 
         let result = self
             .pool
-            .resolve(
-                resolver,
-                fqdn,
-                &query_type,
-                &self.transport,
-                self.recursion,
-            )
+            .resolve(resolver, fqdn, &query_type, &self.transport, self.recursion)
             .await;
 
         self.query_counter.fetch_add(1, Ordering::Relaxed);

--- a/src/modes/subdomain_enumerator.rs
+++ b/src/modes/subdomain_enumerator.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, anyhow};
 use colored::Colorize;
 use rand::Rng;
 use std::fmt::Write;
-use std::net::Ipv4Addr;
+use std::net::SocketAddr;
 use std::{
     collections::HashSet,
     io::{self},
@@ -37,7 +37,7 @@ use crate::{
 
 // A type alias for the result sent between threads.
 type SubdomainResult =
-    Result<(String, Ipv4Addr, HashSet<ResourceRecord>), (String, Ipv4Addr, DnsError)>;
+    Result<(String, SocketAddr, HashSet<ResourceRecord>), (String, SocketAddr, DnsError)>;
 #[derive(Clone)]
 struct SubdomainContext {
     lookup: LookupContext,
@@ -50,7 +50,7 @@ const DEFAULT_QUERY_TYPES: &[QueryType] = &[QueryType::A, QueryType::AAAA];
 #[allow(clippy::too_many_lines)]
 pub async fn enumerate_subdomains(
     cmd_args: &CommandArgs,
-    dns_resolver_list: &[Ipv4Addr],
+    dns_resolver_list: &[SocketAddr],
 ) -> Result<()> {
     let interrupted = interrupt::initialize_interrupt_handler()?;
 
@@ -242,7 +242,7 @@ async fn resolve_subdomain(ctx: &SubdomainContext, subdomain: &str) -> Subdomain
     let fqdn = format!("{}.{}", subdomain, ctx.target);
     let mut aggregated = HashSet::new();
     let mut first_failure: Option<QueryFailure> = None;
-    let mut success_resolver: Option<Ipv4Addr> = None;
+    let mut success_resolver: Option<SocketAddr> = None;
     let mut first_query = true;
 
     let primary_result = ctx
@@ -301,7 +301,7 @@ async fn resolve_subdomain(ctx: &SubdomainContext, subdomain: &str) -> Subdomain
 async fn process_failed_subdomains(
     cmd_args: &CommandArgs,
     pool: &AsyncResolver,
-    dns_resolvers: &[Ipv4Addr],
+    dns_resolvers: &[SocketAddr],
     failed_subdomains: Vec<String>,
     interrupt: &AtomicBool,
     query_plan: &QueryPlan,
@@ -376,7 +376,7 @@ fn read_wordlist(wordlist_path: Option<&String>) -> Result<Vec<String>> {
     }
 }
 
-async fn handle_wildcard_domain(args: &CommandArgs, dns_resolvers: &[Ipv4Addr]) -> Result<bool> {
+async fn handle_wildcard_domain(args: &CommandArgs, dns_resolvers: &[SocketAddr]) -> Result<bool> {
     if check_wildcard_domain(args, dns_resolvers).await? {
         log_warn!("Warning: Wildcard domain detected. Results may include false positives!");
         log_question!("Do you want to continue? (y/n): ");
@@ -396,7 +396,7 @@ async fn handle_wildcard_domain(args: &CommandArgs, dns_resolvers: &[Ipv4Addr]) 
     Ok(false)
 }
 
-async fn check_wildcard_domain(args: &CommandArgs, dns_resolvers: &[Ipv4Addr]) -> Result<bool> {
+async fn check_wildcard_domain(args: &CommandArgs, dns_resolvers: &[SocketAddr]) -> Result<bool> {
     const ATTEMPTS: u8 = 3;
     const MAX_PREFIX_LENGTH: usize = 63;
 
@@ -423,7 +423,7 @@ async fn check_wildcard_domain(args: &CommandArgs, dns_resolvers: &[Ipv4Addr]) -
         let query_type = &DEFAULT_QUERY_TYPES[rng.random_range(0..DEFAULT_QUERY_TYPES.len())];
 
         if resolver_pool
-            .resolve(resolver, &fqdn, query_type, &args.transport_protocol, true)
+            .resolve(*resolver, &fqdn, query_type, &args.transport_protocol, true)
             .await
             .is_ok()
         {
@@ -442,7 +442,7 @@ async fn check_wildcard_domain(args: &CommandArgs, dns_resolvers: &[Ipv4Addr]) -
 fn print_query_result(
     args: &CommandArgs,
     subdomain: &str,
-    resolver: Ipv4Addr,
+    resolver: SocketAddr,
     records: Option<&HashSet<ResourceRecord>>,
 ) {
     if args.quiet {
@@ -473,7 +473,7 @@ fn print_query_result(
 fn print_query_error(
     args: &CommandArgs,
     subdomain: &str,
-    resolver: Ipv4Addr,
+    resolver: SocketAddr,
     error: &DnsError,
     retry: bool,
 ) {

--- a/src/modes/tld_expander.rs
+++ b/src/modes/tld_expander.rs
@@ -51,7 +51,8 @@ static TLD_HTTP_CLIENT: LazyLock<
     Client::builder(TokioExecutor::new()).build(https)
 });
 
-type TldResult = Result<(String, SocketAddr, HashSet<ResourceRecord>), (String, SocketAddr, DnsError)>;
+type TldResult =
+    Result<(String, SocketAddr, HashSet<ResourceRecord>), (String, SocketAddr, DnsError)>;
 
 #[derive(Clone)]
 struct TldContext {

--- a/src/modes/tld_expander.rs
+++ b/src/modes/tld_expander.rs
@@ -6,7 +6,7 @@ use hyper::{Method, Request};
 use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 use std::fmt::Write as _;
-use std::net::Ipv4Addr;
+use std::net::SocketAddr;
 use std::{
     cmp::max,
     collections::HashSet,
@@ -51,7 +51,7 @@ static TLD_HTTP_CLIENT: LazyLock<
     Client::builder(TokioExecutor::new()).build(https)
 });
 
-type TldResult = Result<(String, Ipv4Addr, HashSet<ResourceRecord>), (String, Ipv4Addr, DnsError)>;
+type TldResult = Result<(String, SocketAddr, HashSet<ResourceRecord>), (String, SocketAddr, DnsError)>;
 
 #[derive(Clone)]
 struct TldContext {
@@ -60,7 +60,7 @@ struct TldContext {
 }
 
 #[allow(clippy::too_many_lines)]
-pub async fn expand_tlds(cmd_args: &CommandArgs, dns_resolver_list: &[Ipv4Addr]) -> Result<()> {
+pub async fn expand_tlds(cmd_args: &CommandArgs, dns_resolver_list: &[SocketAddr]) -> Result<()> {
     let interrupted = interrupt::initialize_interrupt_handler()?;
     let tld_list_vec = get_tld_list(cmd_args).await?;
     let tld_set: HashSet<String> = tld_list_vec.iter().cloned().collect(); // Keep set for strip_tld
@@ -218,7 +218,7 @@ async fn resolve_tld(ctx: &TldContext, tld: &str) -> TldResult {
 
     let mut aggregated = HashSet::new();
     let mut first_failure: Option<QueryFailure> = None;
-    let mut success_resolver: Option<Ipv4Addr> = None;
+    let mut success_resolver: Option<SocketAddr> = None;
     let mut first_query = true;
 
     let primary_result = ctx
@@ -379,7 +379,7 @@ async fn fetch_and_filter_tld_list() -> Result<Vec<String>> {
     Ok(tld_list)
 }
 
-fn print_query_result(args: &CommandArgs, domain: &str, resolver: Ipv4Addr, response: &str) {
+fn print_query_result(args: &CommandArgs, domain: &str, resolver: SocketAddr, response: &str) {
     if args.quiet {
         return;
     }
@@ -397,7 +397,7 @@ fn print_query_result(args: &CommandArgs, domain: &str, resolver: Ipv4Addr, resp
     log_success!(message);
 }
 
-fn print_query_error(args: &CommandArgs, domain: &str, resolver: Ipv4Addr, error: &DnsError) {
+fn print_query_error(args: &CommandArgs, domain: &str, resolver: SocketAddr, error: &DnsError) {
     if (!args.verbose
         && matches!(
             error,

--- a/src/network/check.rs
+++ b/src/network/check.rs
@@ -1,11 +1,11 @@
 use colored::Colorize;
 use rand::Rng;
 use rand::distr::Alphanumeric;
+use std::net::SocketAddr;
 
 use crate::dns::async_resolver::AsyncResolver;
 use crate::dns::protocol::QueryType;
 use crate::network::types::TransportProtocol;
-use std::net::Ipv4Addr;
 
 const ROOT_SERVER: &str = "rootservers.net";
 
@@ -20,7 +20,7 @@ fn generate_random_domain() -> String {
 
 async fn check_nxdomain_hijacking(
     resolver_pool: &AsyncResolver,
-    server_address: &Ipv4Addr,
+    server_address: SocketAddr,
     transport_protocol: &TransportProtocol,
 ) -> bool {
     let random_domain = generate_random_domain();
@@ -36,7 +36,7 @@ async fn check_nxdomain_hijacking(
         .is_ok()
 }
 
-fn print_status(server_address: Ipv4Addr, status: &str) {
+fn print_status(server_address: SocketAddr, status: &str) {
     let colored_status = match status {
         "OK" => format!("[{}]", status.green()),
         "FAIL" => format!("[{}]", status.red()),
@@ -52,23 +52,23 @@ fn print_status(server_address: Ipv4Addr, status: &str) {
 }
 
 pub async fn check_dns_resolvers(
-    dns_resolvers: &[Ipv4Addr],
+    dns_resolvers: &[SocketAddr],
     transport_protocol: &TransportProtocol,
-) -> Vec<Ipv4Addr> {
-    let mut working_servers: Vec<Ipv4Addr> = Vec::new();
-    let mut failed_servers: Vec<(Ipv4Addr, &str)> = Vec::new();
+) -> Vec<SocketAddr> {
+    let mut working_servers: Vec<SocketAddr> = Vec::new();
+    let mut failed_servers: Vec<(SocketAddr, &str)> = Vec::new();
 
     let resolver_pool = AsyncResolver::new(Some(1)).await.unwrap();
 
     println!("Checking DNS Resolvers...");
 
     for &server in dns_resolvers {
-        let hijacking = check_nxdomain_hijacking(&resolver_pool, &server, transport_protocol).await;
+        let hijacking = check_nxdomain_hijacking(&resolver_pool, server, transport_protocol).await;
 
         let root_server_letter = rand::rng().random_range(b'a'..b'm') as char;
         let domain = format!("{root_server_letter}.{ROOT_SERVER}");
         let normal_query = resolver_pool
-            .resolve(&server, &domain, &QueryType::A, transport_protocol, true)
+            .resolve(server, &domain, &QueryType::A, transport_protocol, true)
             .await;
 
         if hijacking {


### PR DESCRIPTION
This pull request introduces support for custom DNS resolver ports, improves DNS resolver validation, and updates dependencies. The most significant changes are the ability to specify a non-standard port for DNS resolvers, stricter domain validation, and refactoring of resolver handling to use `SocketAddr` throughout the codebase.

**DNS Resolver Port Support and Refactoring:**

- Added support for specifying a custom port for DNS resolvers (e.g., `1.1.1.1:5353`), defaulting to port 53 if not provided, and updated documentation to reflect this new feature.
- Refactored resolver handling throughout the codebase to use `SocketAddr` instead of just `Ipv4Addr`, allowing both IP address and port to be specified and passed through all DNS resolution logic. [[1]](diffhunk://#diff-acb0897f4766d411272687d7e569276582bd5b93478192fd6e5a1d3fb16415b3L142-R141) [[2]](diffhunk://#diff-acb0897f4766d411272687d7e569276582bd5b93478192fd6e5a1d3fb16415b3L171-R170) [[3]](diffhunk://#diff-acb0897f4766d411272687d7e569276582bd5b93478192fd6e5a1d3fb16415b3L204-R206) [[4]](diffhunk://#diff-acb0897f4766d411272687d7e569276582bd5b93478192fd6e5a1d3fb16415b3L238-R238) [[5]](diffhunk://#diff-acb0897f4766d411272687d7e569276582bd5b93478192fd6e5a1d3fb16415b3L279-R274) [[6]](diffhunk://#diff-acb0897f4766d411272687d7e569276582bd5b93478192fd6e5a1d3fb16415b3L298-R293) [[7]](diffhunk://#diff-acb0897f4766d411272687d7e569276582bd5b93478192fd6e5a1d3fb16415b3L330-R325) [[8]](diffhunk://#diff-acb0897f4766d411272687d7e569276582bd5b93478192fd6e5a1d3fb16415b3L355-R350) [[9]](diffhunk://#diff-d18fae6555a533ecf91fc88662ea72a71dc6318a1b2561bdc32ef08bcac32da1R6-R8) [[10]](diffhunk://#diff-799343799fb0ddbfcd957f8adfa18998555b73f4da1cafad1986585cc9e078daL3-R29) [[11]](diffhunk://#diff-799343799fb0ddbfcd957f8adfa18998555b73f4da1cafad1986585cc9e078daL39-R44) [[12]](diffhunk://#diff-799343799fb0ddbfcd957f8adfa18998555b73f4da1cafad1986585cc9e078daL60-R65) [[13]](diffhunk://#diff-799343799fb0ddbfcd957f8adfa18998555b73f4da1cafad1986585cc9e078daL77-R82) [[14]](diffhunk://#diff-799343799fb0ddbfcd957f8adfa18998555b73f4da1cafad1986585cc9e078daL95-R114) [[15]](diffhunk://#diff-799343799fb0ddbfcd957f8adfa18998555b73f4da1cafad1986585cc9e078daL164-R189) [[16]](diffhunk://#diff-799343799fb0ddbfcd957f8adfa18998555b73f4da1cafad1986585cc9e078daL191-R212) [[17]](diffhunk://#diff-799343799fb0ddbfcd957f8adfa18998555b73f4da1cafad1986585cc9e078daL212-R233) [[18]](diffhunk://#diff-799343799fb0ddbfcd957f8adfa18998555b73f4da1cafad1986585cc9e078daL224-R242) [[19]](diffhunk://#diff-799343799fb0ddbfcd957f8adfa18998555b73f4da1cafad1986585cc9e078daL240-R262) [[20]](diffhunk://#diff-799343799fb0ddbfcd957f8adfa18998555b73f4da1cafad1986585cc9e078daL253-R278)

**Domain and Target Validation Improvements:**

- Improved domain validation to enforce maximum domain and label lengths and normalize domains to lowercase for DNS case-insensitivity.
- Enhanced CSV IP list validation to ensure all entries are valid IPs and normalized output.

**Dependency Updates:**

- Updated dependencies in `Cargo.toml`, including `colored` to 3.1.1 and `thiserror` to 2.0.18. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L4-R12) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L23-R23)

**Code Cleanup:**

- Removed the unused `DNS_PORT` constant from `async_resolver.rs` in favor of a shared `DEFAULT_DNS_PORT` constant. [[1]](diffhunk://#diff-acb0897f4766d411272687d7e569276582bd5b93478192fd6e5a1d3fb16415b3L34) [[2]](diffhunk://#diff-d18fae6555a533ecf91fc88662ea72a71dc6318a1b2561bdc32ef08bcac32da1R6-R8)

These changes collectively improve flexibility for DNS resolver configuration, increase robustness in input validation, and modernize the codebase for maintainability.